### PR TITLE
feat(transform): replace sma50_atr_distance with sma_20

### DIFF
--- a/src/tickerlake/transform.py
+++ b/src/tickerlake/transform.py
@@ -109,11 +109,9 @@ def _compute_adr_pct(bars: pl.DataFrame, period: int = 20) -> pl.DataFrame:
 def compute_metrics(bars: pl.DataFrame) -> pl.DataFrame:
     """Compute per-ticker technical metrics.
 
-    Computes: SMA-50, SMA-200, ATR-14, ATR%, ADR%, SMA50_ATR_Distance, volume_sma_20.
+    Computes: SMA-20, SMA-50, SMA-200, ATR-14, ATR%, ADR%, volume_sma_20.
 
     ATR% (atr_pct) = ATR-14 / close price (ATR as fraction of closing price).
-    SMA50_ATR_Distance (sma50_atr_distance) = ((close - SMA-50) / SMA-50) / ATR%
-    (ATR% multiple from 50-MA).
     """
     sorted_bars = bars.sort(["ticker", "date"])
 
@@ -130,26 +128,16 @@ def compute_metrics(bars: pl.DataFrame) -> pl.DataFrame:
         how="left",
     )
 
-    # Compute derived metrics: sma_50, atr_pct, sma50_atr_distance
+    # Compute derived metrics: sma_20, atr_pct
     df = df.with_columns(
         [
             pl.col("close")
             .cast(pl.Float64)
-            .rolling_mean(window_size=50)
+            .rolling_mean(window_size=20)
             .over("ticker")
             .cast(pl.Float32)
-            .alias("sma_50"),
+            .alias("sma_20"),
             (pl.col("atr_14") / pl.col("close")).cast(pl.Float32).alias("atr_pct"),
-        ]
-    ).with_columns(
-        [
-            (
-                ((pl.col("close") - pl.col("sma_50")) / pl.col("sma_50"))
-                / (pl.col("atr_14") / pl.col("close"))
-            )
-            .fill_nan(None)
-            .cast(pl.Float32)
-            .alias("sma50_atr_distance"),
         ]
     )
 
@@ -157,7 +145,13 @@ def compute_metrics(bars: pl.DataFrame) -> pl.DataFrame:
         [
             pl.col("date"),
             pl.col("ticker"),
-            pl.col("sma_50"),
+            pl.col("sma_20"),
+            pl.col("close")
+            .cast(pl.Float64)
+            .rolling_mean(window_size=50)
+            .over("ticker")
+            .cast(pl.Float32)
+            .alias("sma_50"),
             pl.col("close")
             .cast(pl.Float64)
             .rolling_mean(window_size=200)
@@ -167,7 +161,6 @@ def compute_metrics(bars: pl.DataFrame) -> pl.DataFrame:
             pl.col("atr_14"),
             pl.col("atr_pct"),
             pl.col("adr_pct"),
-            pl.col("sma50_atr_distance"),
             pl.col("volume")
             .cast(pl.Float64)
             .rolling_mean(window_size=20)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -32,23 +32,23 @@ def sample_metrics_df(sample_bars_df: pl.DataFrame) -> pl.DataFrame:
         {
             "date": sample_bars_df["date"],
             "ticker": sample_bars_df["ticker"],
+            "sma_20": [None] * n,
             "sma_50": [None] * n,
             "sma_200": [None] * n,
             "atr_14": [None] * n,
             "atr_pct": [None] * n,
             "adr_pct": [None] * n,
-            "sma50_atr_distance": [None] * n,
             "volume_sma_20": [None] * n,
         },
         schema={
             "date": pl.Date,
             "ticker": pl.Utf8,
+            "sma_20": pl.Float32,
             "sma_50": pl.Float32,
             "sma_200": pl.Float32,
             "atr_14": pl.Float32,
             "atr_pct": pl.Float32,
             "adr_pct": pl.Float32,
-            "sma50_atr_distance": pl.Float32,
             "volume_sma_20": pl.Float32,
         },
     )
@@ -248,11 +248,11 @@ def test_write_consumer_db_schema(
 
     # daily_metrics schema
     assert metrics_schema["date"] == "DATE"
+    assert metrics_schema["sma_20"] == "FLOAT"
     assert metrics_schema["sma_50"] == "FLOAT"
     assert metrics_schema["sma_200"] == "FLOAT"
     assert metrics_schema["atr_14"] == "FLOAT"
     assert metrics_schema["atr_pct"] == "FLOAT"
-    assert metrics_schema["sma50_atr_distance"] == "FLOAT"
 
     # tickers schema
     assert tickers_schema["ticker"] == "VARCHAR"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -99,23 +99,23 @@ def sample_metrics():
         {
             "date": [datetime.date(2024, 1, 2), datetime.date(2024, 1, 2)],
             "ticker": ["AAPL", "MSFT"],
+            "sma_20": [None, None],
             "sma_50": [None, None],
             "sma_200": [None, None],
             "atr_14": [None, None],
             "atr_pct": [None, None],
             "adr_pct": [None, None],
-            "sma50_atr_distance": [None, None],
             "volume_sma_20": [None, None],
         }
     ).cast(
         {
             "date": pl.Date,
+            "sma_20": pl.Float32,
             "sma_50": pl.Float32,
             "sma_200": pl.Float32,
             "atr_14": pl.Float32,
             "atr_pct": pl.Float32,
             "adr_pct": pl.Float32,
-            "sma50_atr_distance": pl.Float32,
             "volume_sma_20": pl.Float32,
         }
     )

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -850,6 +850,15 @@ def test_filter_tickers_removes_unknown(sample_tickers_df: pl.DataFrame):
     assert result["ticker"].to_list() == ["AAPL"]
 
 
+def test_compute_metrics_sma20_correct():
+    bars = make_metric_bars({"AAPL": [float(i) for i in range(1, 31)]})
+
+    result = compute_metrics(bars)
+    row = result.filter(pl.col("date") == datetime.date(2024, 1, 20)).row(0, named=True)
+
+    assert row["sma_20"] == pytest.approx(10.5)
+
+
 def test_compute_metrics_sma50_correct():
     bars = make_metric_bars({"AAPL": [float(i) for i in range(1, 61)]})
 
@@ -866,6 +875,22 @@ def test_compute_metrics_sma200_correct():
     row = result.filter(pl.col("date") == datetime.date(2024, 7, 18)).row(0, named=True)
 
     assert row["sma_200"] == pytest.approx(100.5)
+
+
+def test_compute_metrics_sma20_null_count():
+    bars = make_metric_bars(
+        {
+            "AAPL": [100.0] * 250,
+            "MSFT": [200.0] * 250,
+        }
+    )
+
+    result = compute_metrics(bars)
+    null_counts = result.group_by("ticker").agg(
+        pl.col("sma_20").null_count().alias("nulls")
+    )
+
+    assert null_counts.sort("ticker")["nulls"].to_list() == [19, 19]
 
 
 def test_compute_metrics_sma50_null_count():
@@ -916,6 +941,8 @@ def test_compute_metrics_per_ticker():
         (pl.col("ticker") == "MSFT") & (pl.col("date") == datetime.date(2024, 2, 19))
     ).row(0, named=True)
 
+    assert aapl_row["sma_20"] == pytest.approx(10.0)
+    assert msft_row["sma_20"] == pytest.approx(20.0)
     assert aapl_row["sma_50"] == pytest.approx(10.0)
     assert msft_row["sma_50"] == pytest.approx(20.0)
 
@@ -928,12 +955,12 @@ def test_compute_metrics_output_columns():
     assert result.columns == [
         "date",
         "ticker",
+        "sma_20",
         "sma_50",
         "sma_200",
         "atr_14",
         "atr_pct",
         "adr_pct",
-        "sma50_atr_distance",
         "volume_sma_20",
     ]
 
@@ -1062,7 +1089,7 @@ def test_compute_metrics_no_spy():
     """When SPY is absent, atr_14 is still computed (independent of SPY).
 
     atr_14 must be non-null after warmup — it doesn't depend on SPY.
-    sma_50 and sma_200 are also unaffected.
+    sma_20, sma_50 and sma_200 are also unaffected.
     """
     n = 100
     aapl_ohlc = _make_constant_ohlc(100.0, 1.0, 1.0, n)
@@ -1082,6 +1109,7 @@ def test_compute_metrics_no_spy():
         (pl.col("ticker") == "AAPL")
         & (pl.col("date") == datetime.date(2024, 1, 1) + datetime.timedelta(days=99))
     ).row(0, named=True)
+    assert aapl_late["sma_20"] is not None
     assert aapl_late["sma_50"] is not None
 
 
@@ -1113,94 +1141,6 @@ def test_compute_metrics_atr_pct_null_count():
     assert null_counts.sort("ticker")["nulls"].to_list() == [13, 13]
 
 
-def test_compute_metrics_sma50_atr_distance_correct():
-    """sma50_atr_distance = ((close - sma_50) / sma_50) / (atr_14 / close).
-
-    With _make_constant_ohlc(100.0, 1.0, 1.0, 80):
-    - At row 49: close=149, sma_50=mean(100..149)=124.5, atr_14=2.0
-    - atr_pct = 2.0 / 149.0 ≈ 0.01342
-    - pct_from_50ma = (149 - 124.5) / 124.5 ≈ 0.1968
-    - sma50_atr_distance = 0.1968 / 0.01342 ≈ 14.66
-    """
-    aapl_ohlc = _make_constant_ohlc(100.0, 1.0, 1.0, 80)
-    bars = make_ohlc_bars({"AAPL": aapl_ohlc})
-
-    result = compute_metrics(bars)
-
-    # Row 49 = date 2024-01-01 + 49 days
-    target_date = datetime.date(2024, 1, 1) + datetime.timedelta(days=49)
-    row = result.filter(pl.col("date") == target_date).row(0, named=True)
-
-    close = 100.0 + 49 * 1.0  # = 149.0
-    sma_50 = sum(100.0 + i for i in range(50)) / 50  # = 124.5
-    atr_14 = 2.0  # TR = max(2*spread, ...) = 2.0
-    expected = ((close - sma_50) / sma_50) / (atr_14 / close)
-    assert row["sma50_atr_distance"] == pytest.approx(expected, abs=0.5)
-
-
-def test_compute_metrics_sma50_atr_distance_positive():
-    """sma50_atr_distance > 0 when price is above SMA-50 (uptrend)."""
-    aapl_ohlc = _make_constant_ohlc(100.0, 1.0, 1.0, 60)
-    bars = make_ohlc_bars({"AAPL": aapl_ohlc})
-
-    result = compute_metrics(bars)
-
-    # Last row: price has been rising, so close > sma_50 → distance > 0
-    last_row = result.filter(pl.col("ticker") == "AAPL").row(-1, named=True)
-    assert last_row["sma50_atr_distance"] is not None
-    assert last_row["sma50_atr_distance"] > 0
-
-
-def test_compute_metrics_sma50_atr_distance_negative():
-    """sma50_atr_distance < 0 when price is below SMA-50 (downtrend)."""
-    # Price falls daily: close < sma_50 after warmup
-    aapl_ohlc = _make_constant_ohlc(200.0, -1.0, 1.0, 60)
-    bars = make_ohlc_bars({"AAPL": aapl_ohlc})
-
-    result = compute_metrics(bars)
-
-    last_non_null = (
-        result.filter(pl.col("ticker") == "AAPL")
-        .filter(pl.col("sma50_atr_distance").is_not_null())
-        .row(-1, named=True)
-    )
-    assert last_non_null["sma50_atr_distance"] < 0
-
-
-def test_compute_metrics_sma50_atr_distance_atr_zero():
-    """When ATR=0 (flat price), sma50_atr_distance must be null (not inf/NaN).
-
-    Flat OHLC (100, 100, 100, 100) → ATR=0 after warmup → division by zero
-    → fill_nan(None) → null for all rows.
-    """
-    aapl_ohlc = [(100.0, 100.0, 100.0, 100.0)] * 60
-    bars = make_ohlc_bars({"AAPL": aapl_ohlc})
-
-    result = compute_metrics(bars)
-
-    # All sma50_atr_distance values must be null (ATR=0 → denominator=0 → null)
-    assert result["sma50_atr_distance"].null_count() == len(result)
-
-
-def test_compute_metrics_sma50_atr_distance_null_count():
-    """sma50_atr_distance has exactly 49 leading nulls per ticker (SMA-50 is binding).
-
-    ATR warmup = 13 rows, SMA-50 warmup = 49 rows. SMA-50 is the binding constraint.
-    """
-    aapl_ohlc = _make_constant_ohlc(100.0, 1.0, 1.0, 250)
-    msft_ohlc = _make_constant_ohlc(200.0, 1.0, 1.0, 250)
-    bars = make_ohlc_bars({"AAPL": aapl_ohlc, "MSFT": msft_ohlc})
-
-    result = compute_metrics(bars)
-    null_counts = (
-        result.group_by("ticker")
-        .agg(pl.col("sma50_atr_distance").null_count().alias("nulls"))
-        .sort("ticker")
-    )
-
-    assert null_counts["nulls"].to_list() == [49, 49]
-
-
 def test_compute_metrics_atr_pct_no_spy():
     """atr_pct is computed even when SPY is absent (independent of SPY)."""
     n = 30
@@ -1215,21 +1155,6 @@ def test_compute_metrics_atr_pct_no_spy():
     )
     assert len(after_warmup) > 0
     assert after_warmup["atr_pct"].null_count() == 0
-
-
-def test_compute_metrics_sma50_atr_distance_no_spy():
-    """sma50_atr_distance is computed even when SPY is absent."""
-    n = 60
-    aapl_ohlc = _make_constant_ohlc(100.0, 1.0, 1.0, n)
-    bars = make_ohlc_bars({"AAPL": aapl_ohlc})
-
-    result = compute_metrics(bars)
-
-    # After SMA-50 warmup (row 49+), sma50_atr_distance must be non-null
-    non_null_rows = result.filter(
-        (pl.col("ticker") == "AAPL") & pl.col("sma50_atr_distance").is_not_null()
-    )
-    assert len(non_null_rows) > 0
 
 
 def test_compute_metrics_atr_pct_per_ticker():


### PR DESCRIPTION
## Summary

- `compute_metrics()` no longer computes `sma50_atr_distance` (the SMA-50-relative ATR-distance metric) — dropped entirely along with its derivation logic.
- Added a new `sma_20` column (20-day rolling mean of close, Float32), computed the same way as the existing `sma_50`/`sma_200` columns.
- New output columns from `compute_metrics()`: `date, ticker, sma_20, sma_50, sma_200, atr_14, atr_pct, adr_pct, volume_sma_20`.

## Test plan

- Replaced the six `sma50_atr_distance`-specific tests in `test_transform.py` with `sma_20` equivalents (correctness, null-count warmup, per-ticker isolation, no-SPY independence) mirroring the existing `sma_50` test pattern.
- Updated `daily_metrics`/`weekly_metrics` fixtures in `test_load.py` and `test_pipeline.py` to match the new schema.
- `make check` passes: ruff lint/format, xenon complexity gate, 177 tests, 99.77% coverage.
