### PR TITLE
feat(pipeline): add monthly period aggregation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,6 @@ uv run ty check src/                             # Type check
 
 - **MASSIVE_API_KEY** env var is required -- `Config.__post_init__` raises `ValueError` if missing
 - **Two DuckDB files**: `raw.duckdb` (raw bars) and `tickerlake.duckdb` (adjusted bars + metrics + tickers)
-- **Consumer DB tables**: `daily_bars`, `daily_metrics`, `tickers`, `weekly_bars`, `weekly_metrics`
+- **Consumer DB tables**: `daily_bars`, `daily_metrics`, `tickers`, `weekly_bars`, `weekly_metrics`, `monthly_bars`, `monthly_metrics`
 - **Update is incremental and revision-aware**: delegates to the backfill sequence (`_run_backfill(config, bars_start=...)`) with the bars-fetch start narrowed to a trailing `_REVISION_WINDOW_DAYS`-day window of already-cached dates (fetch-then-swap: fetch first, then delete+replace only the dates Massive actually returned data for in that window), so revisions Massive makes to already-published bars (up to ~5 trading days back) get picked up on the next run. Splits/tickers extraction always covers the full `config.start_date`-`config.end_date` range regardless. Consumer db is always fully rebuilt from raw.duckdb.
 - **Python 3.14 only**: `requires-python = ">=3.14,<3.15"` -- uses modern syntax throughout

--- a/src/tickerlake/load.py
+++ b/src/tickerlake/load.py
@@ -111,40 +111,56 @@ def write_consumer_db(
     *,
     weekly_bars: pl.DataFrame | None = None,
     weekly_metrics: pl.DataFrame | None = None,
+    monthly_bars: pl.DataFrame | None = None,
+    monthly_metrics: pl.DataFrame | None = None,
 ) -> None:
-    """Write bars, metrics, tickers, and optionally weekly DataFrames to consumer DuckDB file."""  # noqa: E501
+    """Write bars, metrics, tickers, and optional period DataFrames to consumer DuckDB file."""  # noqa: E501
     with (
         _tmp_parquet(bars) as bars_tmp,
         _tmp_parquet(metrics) as metrics_tmp,
         _tmp_parquet(tickers) as tickers_tmp,
     ):
         con = duckdb.connect(str(path))
-        con.execute(
-            "CREATE OR REPLACE TABLE daily_bars AS "
-            f"{_read_parquet_sql(bars_tmp, 'ticker, date')}"
-        )
-        con.execute(
-            "CREATE OR REPLACE TABLE daily_metrics AS "
-            f"{_read_parquet_sql(metrics_tmp, 'ticker, date')}"
-        )
-        con.execute(
-            "CREATE OR REPLACE TABLE tickers AS "
-            f"{_read_parquet_sql(tickers_tmp, 'ticker')}"
-        )
-        if weekly_bars is not None:
-            with _tmp_parquet(weekly_bars) as wb_tmp:
-                con.execute(
-                    "CREATE OR REPLACE TABLE weekly_bars AS "
-                    f"{_read_parquet_sql(wb_tmp, 'ticker, date')}"
-                )
-        if weekly_metrics is not None:
-            with _tmp_parquet(weekly_metrics) as wm_tmp:
-                con.execute(
-                    "CREATE OR REPLACE TABLE weekly_metrics AS "
-                    f"{_read_parquet_sql(wm_tmp, 'ticker, date')}"
-                )
-        con.execute("CHECKPOINT")
-        con.close()
+        try:
+            con.execute(
+                "CREATE OR REPLACE TABLE daily_bars AS "
+                f"{_read_parquet_sql(bars_tmp, 'ticker, date')}"
+            )
+            con.execute(
+                "CREATE OR REPLACE TABLE daily_metrics AS "
+                f"{_read_parquet_sql(metrics_tmp, 'ticker, date')}"
+            )
+            con.execute(
+                "CREATE OR REPLACE TABLE tickers AS "
+                f"{_read_parquet_sql(tickers_tmp, 'ticker')}"
+            )
+            if weekly_bars is not None:
+                with _tmp_parquet(weekly_bars) as wb_tmp:
+                    con.execute(
+                        "CREATE OR REPLACE TABLE weekly_bars AS "
+                        f"{_read_parquet_sql(wb_tmp, 'ticker, date')}"
+                    )
+            if weekly_metrics is not None:
+                with _tmp_parquet(weekly_metrics) as wm_tmp:
+                    con.execute(
+                        "CREATE OR REPLACE TABLE weekly_metrics AS "
+                        f"{_read_parquet_sql(wm_tmp, 'ticker, date')}"
+                    )
+            if monthly_bars is not None:
+                with _tmp_parquet(monthly_bars) as mb_tmp:
+                    con.execute(
+                        "CREATE OR REPLACE TABLE monthly_bars AS "
+                        f"{_read_parquet_sql(mb_tmp, 'ticker, date')}"
+                    )
+            if monthly_metrics is not None:
+                with _tmp_parquet(monthly_metrics) as mm_tmp:
+                    con.execute(
+                        "CREATE OR REPLACE TABLE monthly_metrics AS "
+                        f"{_read_parquet_sql(mm_tmp, 'ticker, date')}"
+                    )
+            con.execute("CHECKPOINT")
+        finally:
+            con.close()
 
 
 def write_splits(splits: pl.DataFrame, path: Path) -> None:

--- a/src/tickerlake/pipeline.py
+++ b/src/tickerlake/pipeline.py
@@ -23,6 +23,7 @@ from tickerlake.load import (
 )
 from tickerlake.transform import (
     adjust_splits,
+    aggregate_to_monthly,
     aggregate_to_weekly,
     compute_metrics,
     filter_tickers,
@@ -183,6 +184,10 @@ def _run_backfill(config: Config, *, bars_start: datetime.date | None = None) ->
     weekly_bars = aggregate_to_weekly(bars)
     logger.info("Computing weekly metrics...")
     weekly_metrics = compute_metrics(weekly_bars)
+    logger.info("Aggregating monthly bars...")
+    monthly_bars = aggregate_to_monthly(bars)
+    logger.info("Computing monthly metrics...")
+    monthly_metrics = compute_metrics(monthly_bars)
 
     logger.info("Writing consumer DB to %s...", consumer_path)
     write_consumer_db(
@@ -192,6 +197,8 @@ def _run_backfill(config: Config, *, bars_start: datetime.date | None = None) ->
         consumer_path,
         weekly_bars=weekly_bars,
         weekly_metrics=weekly_metrics,
+        monthly_bars=monthly_bars,
+        monthly_metrics=monthly_metrics,
     )
 
     n_tickers = bars["ticker"].n_unique()

--- a/src/tickerlake/transform.py
+++ b/src/tickerlake/transform.py
@@ -171,24 +171,20 @@ def compute_metrics(bars: pl.DataFrame) -> pl.DataFrame:
     )
 
 
-def aggregate_to_weekly(bars: pl.DataFrame) -> pl.DataFrame:
-    """Aggregate daily OHLCV bars into weekly bars per ticker.
-
-    Weekly grouping is based on each row's calendar Friday for the ISO week.
-    The output date is the actual last trading day present in that ticker-week.
-    """
+def _aggregate_to_period(bars: pl.DataFrame, every: str) -> pl.DataFrame:
+    """Aggregate daily OHLCV bars into calendar periods per ticker."""
     if bars.is_empty():
         return pl.DataFrame(schema=DAILY_AGGS_SCHEMA)
 
-    sorted_bars = bars.sort(["ticker", "date"])
-    bars_with_week_end = sorted_bars.with_columns(
-        (pl.col("date") + pl.duration(days=(4 - pl.col("date").dt.weekday()))).alias(
-            "week_end"
-        )
-    )
-
     return (
-        bars_with_week_end.group_by(["ticker", "week_end"])
+        bars.sort(["ticker", "date"])
+        .group_by_dynamic(
+            "date",
+            every=every,
+            period=every,
+            group_by="ticker",
+            start_by="monday" if every == "1w" else "window",
+        )
         .agg(
             [
                 pl.col("open").sort_by("date").first().cast(pl.Float32).alias("open"),
@@ -196,12 +192,37 @@ def aggregate_to_weekly(bars: pl.DataFrame) -> pl.DataFrame:
                 pl.col("low").min().cast(pl.Float32).alias("low"),
                 pl.col("close").sort_by("date").last().cast(pl.Float32).alias("close"),
                 pl.col("volume").sum().cast(pl.Float32).alias("volume"),
-                pl.col("vwap").sort_by("date").last().cast(pl.Float32).alias("vwap"),
+                pl.when(pl.col("volume").sum() == 0)
+                .then(None)
+                .otherwise(
+                    (pl.col("vwap") * pl.col("volume")).sum() / pl.col("volume").sum()
+                )
+                .cast(pl.Float32)
+                .alias("vwap"),
                 pl.col("transactions").sum().cast(pl.UInt32).alias("transactions"),
-                pl.col("date").max().alias("date"),
+                pl.col("date").max().alias("period_date"),
             ]
         )
-        .drop("week_end")
+        .drop("date")
+        .rename({"period_date": "date"})
         .sort(["ticker", "date"])
         .select(list(DAILY_AGGS_SCHEMA.keys()))
     )
+
+
+def aggregate_to_weekly(bars: pl.DataFrame) -> pl.DataFrame:
+    """Aggregate daily OHLCV bars into weekly bars per ticker.
+
+    Weekly grouping is by calendar week. The output date is the actual last
+    trading day present in that ticker-week.
+    """
+    return _aggregate_to_period(bars, "1w")
+
+
+def aggregate_to_monthly(bars: pl.DataFrame) -> pl.DataFrame:
+    """Aggregate daily OHLCV bars into monthly bars per ticker.
+
+    Monthly grouping is by calendar month. The output date is the actual last
+    trading day present in that ticker-month.
+    """
+    return _aggregate_to_period(bars, "1mo")

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -423,6 +423,31 @@ def test_write_consumer_db_weekly_tables_created(
     assert "weekly_metrics" in tables
 
 
+def test_write_consumer_db_monthly_tables_created(
+    tmp_path: Path,
+    sample_bars_df: pl.DataFrame,
+    sample_metrics_df: pl.DataFrame,
+    sample_tickers_df: pl.DataFrame,
+) -> None:
+    """Monthly tables exist when monthly params are provided."""
+    db_path = tmp_path / "tickerlake.duckdb"
+    write_consumer_db(
+        sample_bars_df,
+        sample_metrics_df,
+        sample_tickers_df,
+        db_path,
+        monthly_bars=sample_bars_df,
+        monthly_metrics=sample_metrics_df,
+    )
+    con = duckdb.connect(str(db_path), read_only=True)
+    try:
+        tables = {row[0] for row in con.execute("SHOW TABLES").fetchall()}
+    finally:
+        con.close()
+    assert "monthly_bars" in tables
+    assert "monthly_metrics" in tables
+
+
 def test_write_consumer_db_weekly_tables_optional(
     tmp_path: Path,
     sample_bars_df: pl.DataFrame,
@@ -437,6 +462,8 @@ def test_write_consumer_db_weekly_tables_optional(
     con.close()
     assert "weekly_bars" not in tables
     assert "weekly_metrics" not in tables
+    assert "monthly_bars" not in tables
+    assert "monthly_metrics" not in tables
     assert "weekly_hvcs" not in tables
     assert len(tables) == 3  # daily_bars, daily_metrics, tickers
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -133,6 +133,7 @@ def pipeline_mocks():
         extract_tickers=DEFAULT,
         adjust_splits=DEFAULT,
         filter_tickers=DEFAULT,
+        aggregate_to_monthly=DEFAULT,
         aggregate_to_weekly=DEFAULT,
         compute_metrics=DEFAULT,
         delete_raw_dates=DEFAULT,
@@ -155,6 +156,7 @@ def _wire_defaults(mocks, sample_bars, sample_splits, sample_tickers, sample_met
     mocks["extract_tickers"].return_value = sample_tickers
     mocks["adjust_splits"].return_value = sample_bars
     mocks["filter_tickers"].return_value = sample_bars
+    mocks["aggregate_to_monthly"].return_value = sample_bars
     mocks["aggregate_to_weekly"].return_value = sample_bars
     mocks["compute_metrics"].return_value = sample_metrics
     mocks["delete_raw_dates"].return_value = None
@@ -201,7 +203,7 @@ def test_backfill_calls_transform_in_order(
     pipeline_mocks["filter_tickers"].assert_called_once()
     assert pipeline_mocks["filter_tickers"].call_args[0][1] is sample_tickers
 
-    assert pipeline_mocks["compute_metrics"].call_count == 2
+    assert pipeline_mocks["compute_metrics"].call_count == 3
 
 
 def test_backfill_calls_write_raw_db(
@@ -1018,10 +1020,10 @@ def test_backfill_calls_aggregate_to_weekly(
     assert call_args[0][0] is sample_bars
 
 
-def test_backfill_computes_weekly_metrics(
+def test_backfill_calls_aggregate_to_monthly(
     pipeline_mocks, tmp_path, sample_bars, sample_splits, sample_tickers, sample_metrics
 ):
-    """Backfill computes metrics for daily and weekly bars."""
+    """Backfill calls aggregate_to_monthly with the filtered bars."""
     from tickerlake.pipeline import backfill
 
     _wire_defaults(
@@ -1029,7 +1031,24 @@ def test_backfill_computes_weekly_metrics(
     )
     backfill(_make_config(tmp_path))
 
-    assert pipeline_mocks["compute_metrics"].call_count == 2
+    pipeline_mocks["aggregate_to_monthly"].assert_called_once()
+    call_args = pipeline_mocks["aggregate_to_monthly"].call_args
+    assert call_args is not None
+    assert call_args[0][0] is sample_bars
+
+
+def test_backfill_computes_weekly_metrics(
+    pipeline_mocks, tmp_path, sample_bars, sample_splits, sample_tickers, sample_metrics
+):
+    """Backfill computes metrics for daily, weekly, and monthly bars."""
+    from tickerlake.pipeline import backfill
+
+    _wire_defaults(
+        pipeline_mocks, sample_bars, sample_splits, sample_tickers, sample_metrics
+    )
+    backfill(_make_config(tmp_path))
+
+    assert pipeline_mocks["compute_metrics"].call_count == 3
 
 
 def test_backfill_passes_weekly_to_consumer_db(
@@ -1055,6 +1074,8 @@ def test_backfill_passes_weekly_to_consumer_db(
     call_kwargs = pipeline_mocks["write_consumer_db"].call_args.kwargs
     assert "weekly_bars" in call_kwargs
     assert "weekly_metrics" in call_kwargs
+    assert "monthly_bars" in call_kwargs
+    assert "monthly_metrics" in call_kwargs
 
 
 def test_update_calls_aggregate_to_weekly(
@@ -1070,6 +1091,7 @@ def test_update_calls_aggregate_to_weekly(
     update(_make_config(tmp_path))
 
     pipeline_mocks["aggregate_to_weekly"].assert_called_once()
+    pipeline_mocks["aggregate_to_monthly"].assert_called_once()
 
 
 def test_update_passes_weekly_to_consumer_db(
@@ -1096,6 +1118,8 @@ def test_update_passes_weekly_to_consumer_db(
     call_kwargs = pipeline_mocks["write_consumer_db"].call_args.kwargs
     assert "weekly_bars" in call_kwargs
     assert "weekly_metrics" in call_kwargs
+    assert "monthly_bars" in call_kwargs
+    assert "monthly_metrics" in call_kwargs
 
 
 def test_backfill_persists_splits(

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -13,6 +13,7 @@ filter_tickers = transform.filter_tickers
 _compute_atr = transform._compute_atr
 _compute_adr_pct = transform._compute_adr_pct
 aggregate_to_weekly = transform.aggregate_to_weekly
+aggregate_to_monthly = transform.aggregate_to_monthly
 DAILY_AGGS_SCHEMA = extract.DAILY_AGGS_SCHEMA
 
 
@@ -184,7 +185,14 @@ class TestAggregateToWeekly:
         assert row["low"] == pytest.approx(97.0)
         assert row["close"] == pytest.approx(103.0)
         assert row["volume"] == pytest.approx(6000.0)
-        assert row["vwap"] == pytest.approx(102.8)
+        expected_vwap = (
+            (100.7 * 1000.0)
+            + (103.1 * 1100.0)
+            + (100.2 * 1200.0)
+            + (101.5 * 1300.0)
+            + (102.8 * 1400.0)
+        ) / 6000.0
+        assert row["vwap"] == pytest.approx(expected_vwap)
         assert row["transactions"] == 60
         assert row["date"] == datetime.date(2024, 1, 12)
 
@@ -412,6 +420,66 @@ class TestAggregateToWeekly:
         empty_bars = pl.DataFrame(schema=BARS_SCHEMA)
 
         result = aggregate_to_weekly(empty_bars)
+
+        assert result.is_empty()
+        assert result.columns == list(DAILY_AGGS_SCHEMA.keys())
+        assert result.dtypes == list(DAILY_AGGS_SCHEMA.values())
+
+
+class TestAggregateToMonthly:
+    def test_groups_by_calendar_month_with_actual_last_trading_day(self):
+        bars = make_bars(
+            [
+                {
+                    "date": datetime.date(2024, 1, 30),
+                    "ticker": "AAPL",
+                    "open": 100.0,
+                    "high": 102.0,
+                    "low": 99.0,
+                    "close": 101.0,
+                    "volume": 1000.0,
+                    "vwap": 100.7,
+                    "transactions": 10,
+                },
+                {
+                    "date": datetime.date(2024, 1, 31),
+                    "ticker": "AAPL",
+                    "open": 101.0,
+                    "high": 105.0,
+                    "low": 100.0,
+                    "close": 104.0,
+                    "volume": 1100.0,
+                    "vwap": 103.1,
+                    "transactions": 11,
+                },
+                {
+                    "date": datetime.date(2024, 2, 1),
+                    "ticker": "AAPL",
+                    "open": 104.0,
+                    "high": 106.0,
+                    "low": 98.0,
+                    "close": 99.0,
+                    "volume": 1200.0,
+                    "vwap": 100.2,
+                    "transactions": 12,
+                },
+            ]
+        )
+
+        result = aggregate_to_monthly(bars)
+
+        assert result["date"].to_list() == [
+            datetime.date(2024, 1, 31),
+            datetime.date(2024, 2, 1),
+        ]
+        assert result["volume"].to_list() == pytest.approx([2100.0, 1200.0])
+        expected_january_vwap = ((100.7 * 1000.0) + (103.1 * 1100.0)) / 2100.0
+        assert result["vwap"].to_list() == pytest.approx([expected_january_vwap, 100.2])
+        assert result.columns == list(DAILY_AGGS_SCHEMA.keys())
+        assert result.dtypes == list(DAILY_AGGS_SCHEMA.values())
+
+    def test_empty_input(self):
+        result = aggregate_to_monthly(pl.DataFrame(schema=BARS_SCHEMA))
 
         assert result.is_empty()
         assert result.columns == list(DAILY_AGGS_SCHEMA.keys())


### PR DESCRIPTION
## Summary

- Refactor weekly OHLCV aggregation to use Polars dynamic time windows.
- Add monthly bars and monthly metrics through the transform, pipeline, and DuckDB writer.
- Use volume-weighted VWAP for period bars and keep period dates as the actual last trading day present.
- Update the project knowledge base and tests for the new monthly tables.

## Test plan

- CodeRabbit local review completed once; valid findings were fixed.
- `make check` passes: ruff lint/format, xenon complexity gate, 181 tests, 99.77% coverage.
