### PR TITLE
feat(pipeline): add pivot lookup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ uv run ty check src/                             # Type check
 
 ## NOTES
 
-- **MASSIVE_API_KEY** env var is required -- `Config.__post_init__` raises `ValueError` if missing
+- **MASSIVE_API_KEY** env var is required for Massive-backed commands (`backfill`, `update`, `compact`). `Config.__post_init__` is permissive (may be empty for read-only commands like `pivots` and `info`); enforcement happens at the command boundary via `pipeline._require_api_key` (raises `ValueError("MASSIVE_API_KEY environment variable is required")` on empty key) and in `MassiveClient.__init__` as defense in depth.
 - **Two DuckDB files**: `raw.duckdb` (raw bars) and `tickerlake.duckdb` (adjusted bars + metrics + tickers)
 - **Consumer DB tables**: `daily_bars`, `daily_metrics`, `tickers`, `weekly_bars`, `weekly_metrics`, `monthly_bars`, `monthly_metrics`
 - **Update is incremental and revision-aware**: delegates to the backfill sequence (`_run_backfill(config, bars_start=...)`) with the bars-fetch start narrowed to a trailing `_REVISION_WINDOW_DAYS`-day window of already-cached dates (fetch-then-swap: fetch first, then delete+replace only the dates Massive actually returned data for in that window), so revisions Massive makes to already-published bars (up to ~5 trading days back) get picked up on the next run. Splits/tickers extraction always covers the full `config.start_date`-`config.end_date` range regardless. Consumer db is always fully rebuilt from raw.duckdb.

--- a/src/tickerlake/__init__.py
+++ b/src/tickerlake/__init__.py
@@ -26,6 +26,19 @@ def _parse_date(s: str) -> datetime.date:
         raise argparse.ArgumentTypeError(msg) from err
 
 
+def _parse_positive_int(s: str) -> int:
+    """Parse a positive integer, raising argparse.ArgumentTypeError on failure."""
+    try:
+        value = int(s)
+    except ValueError as err:
+        msg = f"Invalid positive integer: {s!r}."
+        raise argparse.ArgumentTypeError(msg) from err
+    if value < 1:
+        msg = "Value must be >= 1."
+        raise argparse.ArgumentTypeError(msg)
+    return value
+
+
 def _build_parser() -> argparse.ArgumentParser:
     """Build and return the argument parser with all subcommands."""
     parser = argparse.ArgumentParser(
@@ -50,6 +63,24 @@ def _build_parser() -> argparse.ArgumentParser:
         "compact", help="Rebuild raw.duckdb to reclaim space"
     )
     compact_parser.add_argument("--output-dir", type=Path, metavar="DIR")
+
+    pivots_parser = subparsers.add_parser(
+        "pivots", help="Find confirmed pivots for one ticker"
+    )
+    pivots_parser.add_argument("ticker", help="Ticker symbol, e.g. AAPL")
+    pivots_parser.add_argument(
+        "--timeframe",
+        choices=["daily", "weekly", "monthly"],
+        default="weekly",
+        help="Bar timeframe for pivot detection (default: weekly)",
+    )
+    pivots_parser.add_argument(
+        "--k",
+        type=_parse_positive_int,
+        default=4,
+        help="Bars on each side required to confirm a pivot (default: 4)",
+    )
+    pivots_parser.add_argument("--output-dir", type=Path, metavar="DIR")
 
     return parser
 
@@ -79,10 +110,21 @@ def main() -> None:
     config = _make_config(args)
 
     if args.command == "backfill":
-        pipeline.backfill(config)
+        try:
+            pipeline.backfill(config)
+        except ValueError as err:
+            parser.error(str(err))
     elif args.command == "update":
-        pipeline.update(config)
+        try:
+            pipeline.update(config)
+        except ValueError as err:
+            parser.error(str(err))
     elif args.command == "info":
         pipeline.info(config)
     elif args.command == "compact":
         pipeline.compact(config)
+    elif args.command == "pivots":
+        try:
+            pipeline.pivots(config, args.ticker, args.timeframe, args.k)
+        except ValueError as err:
+            parser.error(str(err))

--- a/src/tickerlake/client.py
+++ b/src/tickerlake/client.py
@@ -15,6 +15,9 @@ class MassiveClient:
 
     def __init__(self, config: Config) -> None:
         """Initialize with Config, creating the underlying RESTClient."""
+        if not config.api_key:
+            msg = "MASSIVE_API_KEY environment variable is required"
+            raise ValueError(msg)
         self._client = RESTClient(api_key=config.api_key)
 
     def fetch_daily_aggs(self, date: datetime.date) -> list[Any]:

--- a/src/tickerlake/config.py
+++ b/src/tickerlake/config.py
@@ -11,7 +11,9 @@ class Config:
     """Configuration for tickerlake ETL pipeline.
 
     Attributes:
-        api_key: MASSIVE API key (from MASSIVE_API_KEY env var when available)
+        api_key: MASSIVE API key (loaded from MASSIVE_API_KEY env var when set;
+            may be empty for read-only commands. Massive-backed commands enforce
+            the requirement at their own boundary.)
         output_dir: Directory for output files (defaults to current working directory)
         start_date: Start date for data collection (defaults to 1 year ago)
         end_date: End date for data collection (defaults to today)

--- a/src/tickerlake/config.py
+++ b/src/tickerlake/config.py
@@ -11,7 +11,7 @@ class Config:
     """Configuration for tickerlake ETL pipeline.
 
     Attributes:
-        api_key: MASSIVE API key (required, from MASSIVE_API_KEY env var)
+        api_key: MASSIVE API key (from MASSIVE_API_KEY env var when available)
         output_dir: Directory for output files (defaults to current working directory)
         start_date: Start date for data collection (defaults to 1 year ago)
         end_date: End date for data collection (defaults to today)
@@ -39,7 +39,4 @@ class Config:
         """Validate and normalize configuration after initialization."""
         if not self.api_key:
             self.api_key = os.environ.get("MASSIVE_API_KEY", "")
-        if not self.api_key:
-            msg = "MASSIVE_API_KEY environment variable is required"
-            raise ValueError(msg)
         self.output_dir = Path(self.output_dir).resolve()

--- a/src/tickerlake/load.py
+++ b/src/tickerlake/load.py
@@ -191,6 +191,38 @@ def read_splits(path: Path) -> pl.DataFrame:
         tmp.unlink(missing_ok=True)
 
 
+def read_adjusted_daily_bars_for_ticker(path: Path, ticker: str) -> pl.DataFrame:
+    """Read split-adjusted daily_bars for one ticker from the consumer DB."""
+    if not path.exists():
+        msg = f"Consumer DB not found: {path}"
+        raise ValueError(msg)
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        tmp = Path(f.name)
+    try:
+        con = duckdb.connect(str(path), read_only=True)
+        try:
+            con.execute(
+                "COPY ("
+                "SELECT * FROM daily_bars WHERE ticker = ? ORDER BY ticker, date"
+                f") TO '{tmp}' (FORMAT PARQUET)",
+                [ticker.upper()],
+            )
+        except duckdb.CatalogException as err:
+            msg = f"daily_bars table not found in consumer DB: {path}"
+            raise ValueError(msg) from err
+        finally:
+            con.close()
+
+        bars = pl.read_parquet(tmp)
+        if bars.is_empty():
+            msg = f"No adjusted daily bars found for ticker {ticker.upper()}"
+            raise ValueError(msg)
+        return bars
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
 def compact_raw_db(path: Path) -> None:
     """Rebuild raw.duckdb by exporting and reimporting to reclaim fragmented space."""
     bars = read_raw_db(path)

--- a/src/tickerlake/pipeline.py
+++ b/src/tickerlake/pipeline.py
@@ -16,6 +16,7 @@ from tickerlake.load import (
     delete_raw_dates,
     get_db_info,
     get_existing_dates,
+    read_adjusted_daily_bars_for_ticker,
     read_raw_db,
     write_consumer_db,
     write_raw_db,
@@ -25,8 +26,10 @@ from tickerlake.transform import (
     adjust_splits,
     aggregate_to_monthly,
     aggregate_to_weekly,
+    bars_for_timeframe,
     compute_metrics,
     filter_tickers,
+    find_pivots,
 )
 
 if TYPE_CHECKING:
@@ -211,11 +214,13 @@ def _run_backfill(config: Config, *, bars_start: datetime.date | None = None) ->
 
 def backfill(config: Config) -> None:
     """Run a full backfill of the ETL pipeline from scratch."""
+    _require_api_key(config)
     _run_backfill(config)
 
 
 def update(config: Config) -> None:
     """Incrementally update raw.duckdb with new trading days, then rebuild consumer db."""  # noqa: E501
+    _require_api_key(config)
     raw_path = config.output_dir / "raw.duckdb"
 
     if not raw_path.exists():
@@ -239,6 +244,49 @@ def update(config: Config) -> None:
         config.end_date,
     )
     _run_backfill(config, bars_start=window_start)
+
+
+def find_ticker_pivots(
+    config: Config, ticker: str, timeframe: str = "weekly", k: int = 4
+) -> pl.DataFrame:
+    """Return pivots for a ticker/timeframe from adjusted consumer daily bars."""
+    if k < 1:
+        msg = "k must be >= 1"
+        raise ValueError(msg)
+    if timeframe not in {"daily", "weekly", "monthly"}:
+        msg = "timeframe must be one of: daily, weekly, monthly"
+        raise ValueError(msg)
+    bars = read_adjusted_daily_bars_for_ticker(
+        config.output_dir / "tickerlake.duckdb", ticker
+    )
+    timeframe_bars = bars_for_timeframe(bars, timeframe)
+    return find_pivots(timeframe_bars, k=k)
+
+
+def _require_api_key(config: Config) -> None:
+    """Raise a clear error when a Massive API command lacks credentials."""
+    if not config.api_key:
+        msg = "MASSIVE_API_KEY environment variable is required"
+        raise ValueError(msg)
+
+
+def pivots(config: Config, ticker: str, timeframe: str = "weekly", k: int = 4) -> None:
+    """Log confirmed pivots for a ticker/timeframe without writing any data."""
+    ticker = ticker.upper()
+    result = find_ticker_pivots(config, ticker, timeframe, k)
+    if result.is_empty():
+        logger.warning("No pivots found for %s (%s, k=%d).", ticker, timeframe, k)
+        return
+
+    logger.info("Pivots for %s (%s, k=%d):", ticker, timeframe, k)
+    for row in result.iter_rows(named=True):
+        logger.info(
+            "%s %-4s %10.2f confirmed_at=%s",
+            row["date"],
+            row["pivot_type"],
+            row["price"],
+            row["confirmed_at"],
+        )
 
 
 def _log_db_info(label: str, path: Path) -> None:

--- a/src/tickerlake/pipeline.py
+++ b/src/tickerlake/pipeline.py
@@ -23,6 +23,7 @@ from tickerlake.load import (
     write_splits,
 )
 from tickerlake.transform import (
+    VALID_TIMEFRAMES,
     adjust_splits,
     aggregate_to_monthly,
     aggregate_to_weekly,
@@ -253,8 +254,8 @@ def find_ticker_pivots(
     if k < 1:
         msg = "k must be >= 1"
         raise ValueError(msg)
-    if timeframe not in {"daily", "weekly", "monthly"}:
-        msg = "timeframe must be one of: daily, weekly, monthly"
+    if timeframe not in VALID_TIMEFRAMES:
+        msg = f"timeframe must be one of: {', '.join(sorted(VALID_TIMEFRAMES))}"
         raise ValueError(msg)
     bars = read_adjusted_daily_bars_for_ticker(
         config.output_dir / "tickerlake.duckdb", ticker

--- a/src/tickerlake/transform.py
+++ b/src/tickerlake/transform.py
@@ -3,6 +3,13 @@ import polars as pl
 from tickerlake.extract import DAILY_AGGS_SCHEMA
 
 PRICE_COLUMNS = ("open", "high", "low", "close", "vwap")
+PIVOTS_SCHEMA = {
+    "date": pl.Date,
+    "ticker": pl.Utf8,
+    "pivot_type": pl.Utf8,
+    "price": pl.Float32,
+    "confirmed_at": pl.Date,
+}
 
 
 def adjust_splits(bars: pl.DataFrame, splits: pl.DataFrame) -> pl.DataFrame:
@@ -226,3 +233,104 @@ def aggregate_to_monthly(bars: pl.DataFrame) -> pl.DataFrame:
     trading day present in that ticker-month.
     """
     return _aggregate_to_period(bars, "1mo")
+
+
+def bars_for_timeframe(bars: pl.DataFrame, timeframe: str) -> pl.DataFrame:
+    if timeframe == "daily":
+        return bars.sort(["ticker", "date"]).select(list(DAILY_AGGS_SCHEMA.keys()))
+    if timeframe == "weekly":
+        return aggregate_to_weekly(bars)
+    if timeframe == "monthly":
+        return aggregate_to_monthly(bars)
+    msg = "timeframe must be one of: daily, weekly, monthly"
+    raise ValueError(msg)
+
+
+def _shifted_expressions(
+    column: str, k: int, *, forward: bool = False
+) -> list[pl.Expr]:
+    multiplier = -1 if forward else 1
+    return [
+        pl.col(column).shift(multiplier * offset).over("ticker")
+        for offset in range(1, k + 1)
+    ]
+
+
+def _complete_window_expression(expressions: list[pl.Expr]) -> pl.Expr:
+    return pl.all_horizontal([expr.is_not_null() for expr in expressions])
+
+
+def _pivot_high_expression(
+    prior_highs: list[pl.Expr], next_highs: list[pl.Expr], complete_window: pl.Expr
+) -> pl.Expr:
+    return (
+        complete_window
+        & pl.all_horizontal([pl.col("high") > expr for expr in prior_highs])
+        & pl.all_horizontal([pl.col("high") >= expr for expr in next_highs])
+    )
+
+
+def _pivot_low_expression(
+    prior_lows: list[pl.Expr], next_lows: list[pl.Expr], complete_window: pl.Expr
+) -> pl.Expr:
+    return (
+        complete_window
+        & pl.all_horizontal([pl.col("low") < expr for expr in prior_lows])
+        & pl.all_horizontal([pl.col("low") <= expr for expr in next_lows])
+    )
+
+
+def _select_pivots(
+    classified: pl.DataFrame, flag_column: str, pivot_type: str, price_column: str
+) -> pl.DataFrame:
+    return classified.filter(pl.col(flag_column)).select(
+        [
+            pl.col("date"),
+            pl.col("ticker"),
+            pl.lit(pivot_type).alias("pivot_type"),
+            pl.col(price_column).cast(pl.Float32).alias("price"),
+            pl.col("confirmed_at"),
+        ]
+    )
+
+
+def find_pivots(bars: pl.DataFrame, *, k: int = 4) -> pl.DataFrame:
+    """Find confirmed fractal pivot highs/lows in sorted per-ticker bars.
+
+    A pivot high is greater than each prior k high values and greater than or
+    equal to each next k high values. A pivot low uses the inverse comparisons.
+    The first k and last k rows per ticker are unknown and are not emitted.
+    """
+    if k < 1:
+        msg = "k must be >= 1"
+        raise ValueError(msg)
+    if bars.is_empty():
+        return pl.DataFrame(schema=PIVOTS_SCHEMA)
+
+    sorted_bars = bars.sort(["ticker", "date"])
+    prior_highs = _shifted_expressions("high", k)
+    next_highs = _shifted_expressions("high", k, forward=True)
+    prior_lows = _shifted_expressions("low", k)
+    next_lows = _shifted_expressions("low", k, forward=True)
+    confirmed_at = pl.col("date").shift(-k).over("ticker")
+    confirmed = confirmed_at.is_not_null()
+    complete_window = _complete_window_expression(
+        prior_highs + next_highs + prior_lows + next_lows
+    )
+
+    classified = sorted_bars.with_columns(
+        [
+            _pivot_high_expression(
+                prior_highs, next_highs, complete_window & confirmed
+            ).alias("is_pivot_high"),
+            _pivot_low_expression(
+                prior_lows, next_lows, complete_window & confirmed
+            ).alias("is_pivot_low"),
+            confirmed_at.alias("confirmed_at"),
+        ]
+    )
+
+    high_pivots = _select_pivots(classified, "is_pivot_high", "high", "high")
+    low_pivots = _select_pivots(classified, "is_pivot_low", "low", "low")
+
+    return pl.concat([high_pivots, low_pivots]).sort(["ticker", "date", "pivot_type"])

--- a/src/tickerlake/transform.py
+++ b/src/tickerlake/transform.py
@@ -10,6 +10,7 @@ PIVOTS_SCHEMA = {
     "price": pl.Float32,
     "confirmed_at": pl.Date,
 }
+VALID_TIMEFRAMES = frozenset({"daily", "weekly", "monthly"})
 
 
 def adjust_splits(bars: pl.DataFrame, splits: pl.DataFrame) -> pl.DataFrame:
@@ -242,7 +243,7 @@ def bars_for_timeframe(bars: pl.DataFrame, timeframe: str) -> pl.DataFrame:
         return aggregate_to_weekly(bars)
     if timeframe == "monthly":
         return aggregate_to_monthly(bars)
-    msg = "timeframe must be one of: daily, weekly, monthly"
+    msg = f"timeframe must be one of: {', '.join(sorted(VALID_TIMEFRAMES))}"
     raise ValueError(msg)
 
 
@@ -307,6 +308,10 @@ def find_pivots(bars: pl.DataFrame, *, k: int = 4) -> pl.DataFrame:
     if bars.is_empty():
         return pl.DataFrame(schema=PIVOTS_SCHEMA)
 
+    return _find_pivots_non_empty(bars, k)
+
+
+def _find_pivots_non_empty(bars: pl.DataFrame, k: int) -> pl.DataFrame:
     sorted_bars = bars.sort(["ticker", "date"])
     prior_highs = _shifted_expressions("high", k)
     next_highs = _shifted_expressions("high", k, forward=True)
@@ -333,4 +338,8 @@ def find_pivots(bars: pl.DataFrame, *, k: int = 4) -> pl.DataFrame:
     high_pivots = _select_pivots(classified, "is_pivot_high", "high", "high")
     low_pivots = _select_pivots(classified, "is_pivot_low", "low", "low")
 
-    return pl.concat([high_pivots, low_pivots]).sort(["ticker", "date", "pivot_type"])
+    return (
+        pl.concat([high_pivots, low_pivots])
+        .sort(["ticker", "date", "pivot_type"])
+        .cast(PIVOTS_SCHEMA)  # ty: ignore[invalid-argument-type]
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -192,6 +192,89 @@ class TestCompactSubcommand:
             assert isinstance(config, Config)
             assert config.output_dir == tmp_path
 
+
+class TestPivotsSubcommand:
+    """Test pivots subcommand and its options."""
+
+    def test_pivots_subcommand_calls_pipeline(self, monkeypatch, tmp_path):
+        """Verify pivots subcommand invokes pipeline.pivots."""
+        monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
+        with patch("tickerlake.pipeline.pivots") as mock_pivots:
+            monkeypatch.setattr(
+                "sys.argv",
+                [
+                    "tickerlake",
+                    "pivots",
+                    "aapl",
+                    "--timeframe",
+                    "monthly",
+                    "--k",
+                    "3",
+                    "--output-dir",
+                    str(tmp_path),
+                ],
+            )
+            main()
+            mock_pivots.assert_called_once()
+            config, ticker, timeframe, k = mock_pivots.call_args[0]
+            assert isinstance(config, Config)
+            assert config.output_dir == tmp_path
+            assert ticker == "aapl"
+            assert timeframe == "monthly"
+            assert k == 3
+
+    def test_pivots_defaults_to_weekly_k4(self, monkeypatch):
+        """Verify pivots defaults to weekly timeframe and k=4."""
+        monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
+        with patch("tickerlake.pipeline.pivots") as mock_pivots:
+            monkeypatch.setattr("sys.argv", ["tickerlake", "pivots", "AAPL"])
+            main()
+            _, _, timeframe, k = mock_pivots.call_args[0]
+            assert timeframe == "weekly"
+            assert k == 4
+
+    def test_pivots_without_api_key_dispatches(self, monkeypatch):
+        """Verify read-only pivots command does not require MASSIVE_API_KEY."""
+        monkeypatch.delenv("MASSIVE_API_KEY", raising=False)
+        with patch("tickerlake.pipeline.pivots") as mock_pivots:
+            monkeypatch.setattr("sys.argv", ["tickerlake", "pivots", "AAPL"])
+            main()
+
+        mock_pivots.assert_called_once()
+        config = mock_pivots.call_args[0][0]
+        assert config.api_key == ""
+
+    def test_pivots_invalid_timeframe(self, monkeypatch):
+        """Verify invalid timeframe exits with error."""
+        monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
+        monkeypatch.setattr(
+            "sys.argv", ["tickerlake", "pivots", "AAPL", "--timeframe", "yearly"]
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code != 0
+
+    def test_pivots_invalid_k_parse_failure(self, monkeypatch):
+        """Verify --k must be a positive integer."""
+        monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
+        monkeypatch.setattr("sys.argv", ["tickerlake", "pivots", "AAPL", "--k", "0"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code != 0
+
+    def test_pivots_value_error_becomes_cli_error(self, monkeypatch, capsys):
+        """Verify pivot lookup ValueError exits cleanly without traceback."""
+        monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
+        with patch("tickerlake.pipeline.pivots", side_effect=ValueError("missing db")):
+            monkeypatch.setattr("sys.argv", ["tickerlake", "pivots", "AAPL"])
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code != 0
+        assert "missing db" in captured.err
+        assert "Traceback" not in captured.err
+
     def test_compact_custom_output_dir(self, monkeypatch, tmp_path):
         """Verify --output-dir option sets config.output_dir for compact."""
         monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
@@ -246,3 +329,29 @@ class TestConfigDefaults:
             main()
             config = mock_info.call_args[0][0]
             assert isinstance(config, Config)
+
+    def test_backfill_without_api_key_exits_cleanly(self, monkeypatch, capsys):
+        """Verify Massive commands require MASSIVE_API_KEY at dispatch."""
+        monkeypatch.delenv("MASSIVE_API_KEY", raising=False)
+        monkeypatch.setattr("sys.argv", ["tickerlake", "backfill"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code != 0
+        assert "MASSIVE_API_KEY environment variable is required" in captured.err
+        assert "Traceback" not in captured.err
+
+    def test_update_without_api_key_exits_cleanly(self, monkeypatch, capsys):
+        """Verify update requires MASSIVE_API_KEY at dispatch."""
+        monkeypatch.delenv("MASSIVE_API_KEY", raising=False)
+        monkeypatch.setattr("sys.argv", ["tickerlake", "update"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code != 0
+        assert "MASSIVE_API_KEY environment variable is required" in captured.err
+        assert "Traceback" not in captured.err

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,8 @@
 """Tests for the Massive API client wrapper."""
 
 import datetime
+import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,7 +16,7 @@ def sample_config() -> Config:
     """Create a sample Config for testing."""
     return Config(
         api_key="test-api-key",
-        output_dir="/tmp",
+        output_dir=Path("/tmp"),
         start_date=datetime.date(2024, 1, 1),
         end_date=datetime.date(2024, 12, 31),
         ticker_types=["CS", "ETF", "ETV", "ETN", "ADRC"],
@@ -35,6 +37,19 @@ class TestMassiveClientInit:
 
         mock_rest_class.assert_called_once_with(api_key="test-api-key")
         assert client._client is not None
+
+    @patch("tickerlake.client.RESTClient")
+    def test_init_requires_api_key(self, mock_rest_class: MagicMock) -> None:
+        """MassiveClient rejects missing API keys with a clear message."""
+        with patch.dict(os.environ, {}, clear=True):
+            config = Config(api_key="")
+
+        with pytest.raises(
+            ValueError, match="MASSIVE_API_KEY environment variable is required"
+        ):
+            MassiveClient(config)
+
+        mock_rest_class.assert_not_called()
 
 
 class TestFetchDailyAggs:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,8 +5,6 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 from tickerlake.config import Config
 
 
@@ -19,15 +17,12 @@ class TestApiKey:
             config = Config()
             assert config.api_key == "test-key-123"
 
-    def test_missing_api_key_raises(self) -> None:
-        """Config() without env var raises ValueError with clear message."""
-        with (
-            patch.dict(os.environ, {}, clear=True),
-            pytest.raises(
-                ValueError, match="MASSIVE_API_KEY environment variable is required"
-            ),
-        ):
-            Config()
+    def test_missing_api_key_allowed(self) -> None:
+        """Config() without env var is valid for read-only commands."""
+        with patch.dict(os.environ, {}, clear=True):
+            config = Config(output_dir=Path("./relative/path"))
+        assert config.api_key == ""
+        assert config.output_dir == Path("./relative/path").resolve()
 
 
 class TestDates:

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -13,6 +13,7 @@ from tickerlake.load import (
     delete_raw_dates,
     get_db_info,
     get_existing_dates,
+    read_adjusted_daily_bars_for_ticker,
     read_raw_db,
     read_splits,
     write_consumer_db,
@@ -279,6 +280,54 @@ def test_consumer_query_pattern(
     con.close()
 
     assert len(result) > 0
+
+
+def test_read_adjusted_daily_bars_for_ticker(
+    tmp_path: Path,
+    sample_bars_df: pl.DataFrame,
+    sample_metrics_df: pl.DataFrame,
+    sample_tickers_df: pl.DataFrame,
+) -> None:
+    """read_adjusted_daily_bars_for_ticker() returns sorted rows for one ticker."""
+    db_path = tmp_path / "tickerlake.duckdb"
+    write_consumer_db(sample_bars_df, sample_metrics_df, sample_tickers_df, db_path)
+
+    result = read_adjusted_daily_bars_for_ticker(db_path, "aapl")
+
+    assert isinstance(result, pl.DataFrame)
+    assert set(result["ticker"].to_list()) == {"AAPL"}
+    assert result["date"].to_list() == sorted(result["date"].to_list())
+
+
+def test_read_adjusted_daily_bars_missing_db(tmp_path: Path) -> None:
+    """read_adjusted_daily_bars_for_ticker() rejects a missing consumer DB."""
+    with pytest.raises(ValueError, match="Consumer DB not found"):
+        read_adjusted_daily_bars_for_ticker(tmp_path / "missing.duckdb", "AAPL")
+
+
+def test_read_adjusted_daily_bars_missing_table(tmp_path: Path) -> None:
+    """read_adjusted_daily_bars_for_ticker() rejects DBs without daily_bars."""
+    db_path = tmp_path / "tickerlake.duckdb"
+    con = duckdb.connect(str(db_path))
+    con.execute("CREATE TABLE unrelated (x INT)")
+    con.close()
+
+    with pytest.raises(ValueError, match="daily_bars table not found"):
+        read_adjusted_daily_bars_for_ticker(db_path, "AAPL")
+
+
+def test_read_adjusted_daily_bars_missing_ticker(
+    tmp_path: Path,
+    sample_bars_df: pl.DataFrame,
+    sample_metrics_df: pl.DataFrame,
+    sample_tickers_df: pl.DataFrame,
+) -> None:
+    """read_adjusted_daily_bars_for_ticker() rejects tickers with no rows."""
+    db_path = tmp_path / "tickerlake.duckdb"
+    write_consumer_db(sample_bars_df, sample_metrics_df, sample_tickers_df, db_path)
+
+    with pytest.raises(ValueError, match="No adjusted daily bars found"):
+        read_adjusted_daily_bars_for_ticker(db_path, "ZZZZ")
 
 
 def test_get_db_info(tmp_path: Path, sample_bars_df: pl.DataFrame) -> None:

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -309,8 +309,10 @@ def test_read_adjusted_daily_bars_missing_table(tmp_path: Path) -> None:
     """read_adjusted_daily_bars_for_ticker() rejects DBs without daily_bars."""
     db_path = tmp_path / "tickerlake.duckdb"
     con = duckdb.connect(str(db_path))
-    con.execute("CREATE TABLE unrelated (x INT)")
-    con.close()
+    try:
+        con.execute("CREATE TABLE unrelated (x INT)")
+    finally:
+        con.close()
 
     with pytest.raises(ValueError, match="daily_bars table not found"):
         read_adjusted_daily_bars_for_ticker(db_path, "AAPL")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -26,6 +26,101 @@ def _make_config(tmp_path: Path):
     )
 
 
+def test_find_ticker_pivots_uses_adjusted_daily_consumer_data(
+    tmp_path: Path, sample_bars: pl.DataFrame
+) -> None:
+    """find_ticker_pivots() reads adjusted daily bars then derives timeframe pivots."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    timeframe_bars = sample_bars.filter(pl.col("ticker") == "AAPL")
+    expected = pl.DataFrame(
+        {
+            "date": [datetime.date(2024, 1, 2)],
+            "ticker": ["AAPL"],
+            "pivot_type": ["high"],
+            "price": [152.0],
+            "confirmed_at": [datetime.date(2024, 1, 9)],
+        }
+    )
+
+    with (
+        patch(
+            f"{_PIPELINE}.read_adjusted_daily_bars_for_ticker",
+            return_value=sample_bars,
+        ) as read_bars,
+        patch(
+            f"{_PIPELINE}.bars_for_timeframe", return_value=timeframe_bars
+        ) as bars_for_tf,
+        patch(f"{_PIPELINE}.find_pivots", return_value=expected) as find,
+        patch(f"{_PIPELINE}.write_consumer_db") as write_consumer,
+        patch(f"{_PIPELINE}.write_raw_db") as write_raw,
+        patch(f"{_PIPELINE}.write_splits") as write_splits_mock,
+    ):
+        result = pipeline.find_ticker_pivots(config, "AAPL", "weekly", 5)
+
+    read_bars.assert_called_once_with(config.output_dir / "tickerlake.duckdb", "AAPL")
+    bars_for_tf.assert_called_once_with(sample_bars, "weekly")
+    find.assert_called_once_with(timeframe_bars, k=5)
+    write_consumer.assert_not_called()
+    write_raw.assert_not_called()
+    write_splits_mock.assert_not_called()
+    assert result.equals(expected)
+
+
+def test_pivots_logs_empty_result(tmp_path: Path, caplog) -> None:
+    """pivots() logs a warning when no pivots are found."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    empty = pl.DataFrame(
+        schema={
+            "date": pl.Date,
+            "ticker": pl.Utf8,
+            "pivot_type": pl.Utf8,
+            "price": pl.Float32,
+            "confirmed_at": pl.Date,
+        }
+    )
+
+    with patch(f"{_PIPELINE}.find_ticker_pivots", return_value=empty):
+        pipeline.pivots(config, "AAPL", "daily", 3)
+
+    assert "No pivots found for AAPL" in caplog.text
+
+
+def test_find_ticker_pivots_invalid_k_does_not_read_db(tmp_path: Path) -> None:
+    """find_ticker_pivots() validates k before reading the consumer DB."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+
+    with (
+        patch(f"{_PIPELINE}.read_adjusted_daily_bars_for_ticker") as read_bars,
+        pytest.raises(ValueError, match="k must be >= 1"),
+    ):
+        pipeline.find_ticker_pivots(config, "AAPL", "weekly", 0)
+
+    read_bars.assert_not_called()
+
+
+def test_find_ticker_pivots_invalid_timeframe_does_not_read_db(
+    tmp_path: Path,
+) -> None:
+    """find_ticker_pivots() validates timeframe before reading the consumer DB."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+
+    with (
+        patch(f"{_PIPELINE}.read_adjusted_daily_bars_for_ticker") as read_bars,
+        pytest.raises(ValueError, match="timeframe must be one of"),
+    ):
+        pipeline.find_ticker_pivots(config, "AAPL", "yearly", 5)
+
+    read_bars.assert_not_called()
+
+
 @pytest.fixture
 def sample_bars():
     """Minimal bars DataFrame for pipeline tests."""

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -44,28 +44,29 @@ def test_find_ticker_pivots_uses_adjusted_daily_consumer_data(
         }
     )
 
-    with (
-        patch(
-            f"{_PIPELINE}.read_adjusted_daily_bars_for_ticker",
-            return_value=sample_bars,
-        ) as read_bars,
-        patch(
-            f"{_PIPELINE}.bars_for_timeframe", return_value=timeframe_bars
-        ) as bars_for_tf,
-        patch(f"{_PIPELINE}.find_pivots", return_value=expected) as find,
-        patch(f"{_PIPELINE}.write_consumer_db") as write_consumer,
-        patch(f"{_PIPELINE}.write_raw_db") as write_raw,
-        patch(f"{_PIPELINE}.write_splits") as write_splits_mock,
-    ):
+    with patch.multiple(
+        _PIPELINE,
+        read_adjusted_daily_bars_for_ticker=DEFAULT,
+        bars_for_timeframe=DEFAULT,
+        find_pivots=DEFAULT,
+        write_consumer_db=DEFAULT,
+        write_raw_db=DEFAULT,
+        write_splits=DEFAULT,
+    ) as mocks:
+        mocks["read_adjusted_daily_bars_for_ticker"].return_value = sample_bars
+        mocks["bars_for_timeframe"].return_value = timeframe_bars
+        mocks["find_pivots"].return_value = expected
         result = pipeline.find_ticker_pivots(config, "AAPL", "weekly", 5)
 
-    read_bars.assert_called_once_with(config.output_dir / "tickerlake.duckdb", "AAPL")
-    bars_for_tf.assert_called_once_with(sample_bars, "weekly")
-    find.assert_called_once_with(timeframe_bars, k=5)
-    write_consumer.assert_not_called()
-    write_raw.assert_not_called()
-    write_splits_mock.assert_not_called()
-    assert result.equals(expected)
+        mocks["read_adjusted_daily_bars_for_ticker"].assert_called_once_with(
+            config.output_dir / "tickerlake.duckdb", "AAPL"
+        )
+        mocks["bars_for_timeframe"].assert_called_once_with(sample_bars, "weekly")
+        mocks["find_pivots"].assert_called_once_with(timeframe_bars, k=5)
+        mocks["write_consumer_db"].assert_not_called()
+        mocks["write_raw_db"].assert_not_called()
+        mocks["write_splits"].assert_not_called()
+        assert result.equals(expected)
 
 
 def test_pivots_logs_empty_result(tmp_path: Path, caplog) -> None:
@@ -87,6 +88,36 @@ def test_pivots_logs_empty_result(tmp_path: Path, caplog) -> None:
         pipeline.pivots(config, "AAPL", "daily", 3)
 
     assert "No pivots found for AAPL" in caplog.text
+
+
+def test_pivots_logs_non_empty_result(tmp_path: Path, caplog) -> None:
+    """pivots() logs one INFO line per pivot row when pivots are found."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    pivots_df = pl.DataFrame(
+        {
+            "date": [datetime.date(2024, 1, 2), datetime.date(2024, 1, 5)],
+            "ticker": ["AAPL", "AAPL"],
+            "pivot_type": ["high", "low"],
+            "price": [152.0, 148.0],
+            "confirmed_at": [datetime.date(2024, 1, 9), datetime.date(2024, 1, 12)],
+        }
+    )
+
+    with (
+        patch(f"{_PIPELINE}.find_ticker_pivots", return_value=pivots_df),
+        caplog.at_level("INFO"),
+    ):
+        pipeline.pivots(config, "AAPL", "weekly", 4)
+
+    assert "Pivots for AAPL (weekly, k=4)" in caplog.text
+    assert "high" in caplog.text
+    assert "low" in caplog.text
+    assert "152.00" in caplog.text
+    assert "148.00" in caplog.text
+    assert "2024-01-09" in caplog.text
+    assert "2024-01-12" in caplog.text
 
 
 def test_find_ticker_pivots_invalid_k_does_not_read_db(tmp_path: Path) -> None:

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -473,6 +473,19 @@ def test_aggregate_to_monthly_values_and_last_trading_day():
     assert january["transactions"] == 21
 
 
+def test_aggregate_to_period_empty_input_weekly_and_monthly():
+    """Empty bars short-circuit to DAILY_AGGS_SCHEMA for both weekly and monthly."""
+    empty_bars = pl.DataFrame(schema=BARS_SCHEMA)
+
+    weekly = aggregate_to_weekly(empty_bars)
+    monthly = aggregate_to_monthly(empty_bars)
+
+    for result in (weekly, monthly):
+        assert result.is_empty()
+        assert result.columns == list(DAILY_AGGS_SCHEMA.keys())
+        assert result.dtypes == list(DAILY_AGGS_SCHEMA.values())
+
+
 def test_bars_for_timeframe_daily_weekly_monthly():
     bars = make_metric_bars(
         {"AAPL": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]},

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -14,6 +14,8 @@ _compute_atr = transform._compute_atr
 _compute_adr_pct = transform._compute_adr_pct
 aggregate_to_weekly = transform.aggregate_to_weekly
 aggregate_to_monthly = transform.aggregate_to_monthly
+bars_for_timeframe = transform.bars_for_timeframe
+find_pivots = transform.find_pivots
 DAILY_AGGS_SCHEMA = extract.DAILY_AGGS_SCHEMA
 
 
@@ -416,14 +418,174 @@ class TestAggregateToWeekly:
         assert result.columns == list(DAILY_AGGS_SCHEMA.keys())
         assert result.dtypes == list(DAILY_AGGS_SCHEMA.values())
 
-    def test_empty_input(self):
-        empty_bars = pl.DataFrame(schema=BARS_SCHEMA)
 
-        result = aggregate_to_weekly(empty_bars)
+def test_aggregate_to_monthly_values_and_last_trading_day():
+    bars = make_bars(
+        [
+            {
+                "date": datetime.date(2024, 1, 30),
+                "ticker": "AAPL",
+                "open": 100.0,
+                "high": 102.0,
+                "low": 99.0,
+                "close": 101.0,
+                "volume": 1000.0,
+                "vwap": 100.5,
+                "transactions": 10,
+            },
+            {
+                "date": datetime.date(2024, 1, 31),
+                "ticker": "AAPL",
+                "open": 101.0,
+                "high": 105.0,
+                "low": 98.0,
+                "close": 104.0,
+                "volume": 1100.0,
+                "vwap": 103.5,
+                "transactions": 11,
+            },
+            {
+                "date": datetime.date(2024, 2, 1),
+                "ticker": "AAPL",
+                "open": 104.0,
+                "high": 106.0,
+                "low": 103.0,
+                "close": 105.0,
+                "volume": 1200.0,
+                "vwap": 104.5,
+                "transactions": 12,
+            },
+        ]
+    )
 
-        assert result.is_empty()
-        assert result.columns == list(DAILY_AGGS_SCHEMA.keys())
-        assert result.dtypes == list(DAILY_AGGS_SCHEMA.values())
+    result = aggregate_to_monthly(bars)
+    january = result.row(0, named=True)
+    expected_vwap = (100.5 * 1000.0 + 103.5 * 1100.0) / 2100.0
+
+    assert result.columns == list(DAILY_AGGS_SCHEMA.keys())
+    assert january["date"] == datetime.date(2024, 1, 31)
+    assert january["open"] == pytest.approx(100.0)
+    assert january["high"] == pytest.approx(105.0)
+    assert january["low"] == pytest.approx(98.0)
+    assert january["close"] == pytest.approx(104.0)
+    assert january["volume"] == pytest.approx(2100.0)
+    assert january["vwap"] == pytest.approx(expected_vwap)
+    assert january["transactions"] == 21
+
+
+def test_bars_for_timeframe_daily_weekly_monthly():
+    bars = make_metric_bars(
+        {"AAPL": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]},
+        datetime.date(2024, 1, 29),
+    )
+
+    daily = bars_for_timeframe(bars.reverse(), "daily")
+    weekly = bars_for_timeframe(bars, "weekly")
+    monthly = bars_for_timeframe(bars, "monthly")
+
+    assert daily["date"].to_list() == sorted(bars["date"].to_list())
+    assert weekly["date"].to_list() == [datetime.date(2024, 2, 3)]
+    assert monthly["date"].to_list() == [
+        datetime.date(2024, 1, 31),
+        datetime.date(2024, 2, 3),
+    ]
+
+
+def test_bars_for_timeframe_invalid():
+    with pytest.raises(ValueError, match="timeframe"):
+        bars_for_timeframe(pl.DataFrame(schema=BARS_SCHEMA), "yearly")
+
+
+def test_find_pivots_high_low_plateau_and_confirmation():
+    bars = make_ohlc_bars(
+        {
+            "AAPL": [
+                (10.0, 10.0, 5.0, 10.0),
+                (11.0, 12.0, 4.0, 11.0),
+                (12.0, 15.0, 6.0, 12.0),
+                (12.0, 15.0, 7.0, 12.0),
+                (11.0, 11.0, 3.0, 11.0),
+                (10.0, 10.0, 4.0, 10.0),
+                (9.0, 9.0, 5.0, 9.0),
+            ]
+        }
+    )
+
+    result = find_pivots(bars, k=1)
+
+    assert result.to_dicts() == [
+        {
+            "date": datetime.date(2024, 1, 2),
+            "ticker": "AAPL",
+            "pivot_type": "low",
+            "price": 4.0,
+            "confirmed_at": datetime.date(2024, 1, 3),
+        },
+        {
+            "date": datetime.date(2024, 1, 3),
+            "ticker": "AAPL",
+            "pivot_type": "high",
+            "price": 15.0,
+            "confirmed_at": datetime.date(2024, 1, 4),
+        },
+        {
+            "date": datetime.date(2024, 1, 5),
+            "ticker": "AAPL",
+            "pivot_type": "low",
+            "price": 3.0,
+            "confirmed_at": datetime.date(2024, 1, 6),
+        },
+    ]
+
+
+def test_find_pivots_edges_remain_unknown():
+    bars = make_ohlc_bars(
+        {
+            "AAPL": [
+                (1.0, 100.0, 0.0, 1.0),
+                (1.0, 1.0, 1.0, 1.0),
+                (1.0, 99.0, -1.0, 1.0),
+            ]
+        }
+    )
+
+    result = find_pivots(bars, k=1)
+
+    assert result.is_empty()
+
+
+def test_find_pivots_k2_first_and_last_two_bars_never_emitted():
+    bars = make_ohlc_bars(
+        {
+            "AAPL": [
+                (1.0, 100.0, 0.0, 1.0),
+                (1.0, 9.0, 1.0, 1.0),
+                (1.0, 5.0, 5.0, 1.0),
+                (1.0, 20.0, 2.0, 1.0),
+                (1.0, 6.0, 6.0, 1.0),
+                (1.0, 8.0, -1.0, 1.0),
+                (1.0, 101.0, -2.0, 1.0),
+            ]
+        }
+    )
+
+    result = find_pivots(bars, k=2)
+
+    assert result["date"].to_list() == [datetime.date(2024, 1, 4)]
+    assert result["confirmed_at"].null_count() == 0
+
+
+def test_find_pivots_invalid_k():
+    with pytest.raises(ValueError, match="k"):
+        find_pivots(pl.DataFrame(schema=BARS_SCHEMA), k=0)
+
+
+def test_find_pivots_empty_input():
+    result = find_pivots(pl.DataFrame(schema=BARS_SCHEMA), k=2)
+
+    assert result.is_empty()
+    assert result.columns == ["date", "ticker", "pivot_type", "price", "confirmed_at"]
+    assert result.dtypes == [pl.Date, pl.Utf8, pl.Utf8, pl.Float32, pl.Date]
 
 
 class TestAggregateToMonthly:


### PR DESCRIPTION
## Summary

- Add confirmed fractal pivot detection with daily, weekly, and monthly timeframe support.
- Add on-demand ticker pivot lookup from split-adjusted consumer `daily_bars` without persisting pivot tables.
- Add `tickerlake pivots TICKER --timeframe {daily,weekly,monthly} --k N`, defaulting weekly pivots to `k=4`.
- Allow read-only local commands to run without `MASSIVE_API_KEY` while keeping Massive-backed commands guarded.

## Test plan

- CodeRabbit local review completed once; partial findings were reviewed and skipped as non-actionable test-style suggestions.
- `make check` passes: ruff lint/format, xenon complexity gate, 205 tests, 98.72% coverage.
