### PR TITLE
feat(load): validate consumer table schemas

### DIFF
--- a/src/tickerlake/load.py
+++ b/src/tickerlake/load.py
@@ -8,8 +8,52 @@ from typing import TYPE_CHECKING
 import duckdb
 import polars as pl
 
+from tickerlake.extract import DAILY_AGGS_SCHEMA, TICKERS_SCHEMA
+
 if TYPE_CHECKING:
     import datetime
+
+
+_METRICS_SCHEMA = {
+    "date": pl.Date,
+    "ticker": pl.Utf8,
+    "sma_20": pl.Float32,
+    "sma_50": pl.Float32,
+    "sma_200": pl.Float32,
+    "atr_14": pl.Float32,
+    "atr_pct": pl.Float32,
+    "adr_pct": pl.Float32,
+    "volume_sma_20": pl.Float32,
+}
+
+
+def _validate_schema(
+    table: str, df: pl.DataFrame, expected: dict[str, pl.DataType]
+) -> None:
+    """Validate a DataFrame schema before writing a DuckDB table."""
+    mismatches = _schema_mismatches(dict(df.schema), expected)
+
+    if mismatches:
+        msg = f"{table} schema mismatch: {'; '.join(mismatches)}"
+        raise ValueError(msg)
+
+
+def _schema_mismatches(
+    actual: dict[str, pl.DataType], expected: dict[str, pl.DataType]
+) -> list[str]:
+    missing = [col for col in expected if col not in actual]
+    extra = [col for col in actual if col not in expected]
+    wrong_dtype = [
+        f"{col}: expected {dtype}, got {actual[col]}"
+        for col, dtype in expected.items()
+        if col in actual and actual[col] != dtype
+    ]
+
+    return [
+        *([f"missing columns: {', '.join(missing)}"] if missing else []),
+        *([f"unexpected columns: {', '.join(extra)}"] if extra else []),
+        *wrong_dtype,
+    ]
 
 
 @contextmanager
@@ -115,6 +159,18 @@ def write_consumer_db(
     monthly_metrics: pl.DataFrame | None = None,
 ) -> None:
     """Write bars, metrics, tickers, and optional period DataFrames to consumer DuckDB file."""  # noqa: E501
+    _validate_schema("daily_bars", bars, DAILY_AGGS_SCHEMA)
+    _validate_schema("daily_metrics", metrics, _METRICS_SCHEMA)
+    _validate_schema("tickers", tickers, TICKERS_SCHEMA)
+    if weekly_bars is not None:
+        _validate_schema("weekly_bars", weekly_bars, DAILY_AGGS_SCHEMA)
+    if weekly_metrics is not None:
+        _validate_schema("weekly_metrics", weekly_metrics, _METRICS_SCHEMA)
+    if monthly_bars is not None:
+        _validate_schema("monthly_bars", monthly_bars, DAILY_AGGS_SCHEMA)
+    if monthly_metrics is not None:
+        _validate_schema("monthly_metrics", monthly_metrics, _METRICS_SCHEMA)
+
     with (
         _tmp_parquet(bars) as bars_tmp,
         _tmp_parquet(metrics) as metrics_tmp,

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -259,6 +259,98 @@ def test_write_consumer_db_schema(
     assert tickers_schema["active"] == "BOOLEAN"
 
 
+def test_write_consumer_db_rejects_missing_column(
+    tmp_path: Path,
+    sample_bars_df: pl.DataFrame,
+    sample_metrics_df: pl.DataFrame,
+    sample_tickers_df: pl.DataFrame,
+) -> None:
+    """Consumer schema validation rejects missing required columns."""
+    db_path = tmp_path / "tickerlake.duckdb"
+    bad_metrics = sample_metrics_df.drop("sma_20")
+
+    with pytest.raises(ValueError, match=r"daily_metrics.*missing columns: sma_20"):
+        write_consumer_db(sample_bars_df, bad_metrics, sample_tickers_df, db_path)
+
+
+def test_write_consumer_db_rejects_wrong_dtype(
+    tmp_path: Path,
+    sample_bars_df: pl.DataFrame,
+    sample_metrics_df: pl.DataFrame,
+    sample_tickers_df: pl.DataFrame,
+) -> None:
+    """Consumer schema validation rejects incorrect column dtypes."""
+    db_path = tmp_path / "tickerlake.duckdb"
+    bad_bars = sample_bars_df.with_columns(pl.col("close").cast(pl.Float64))
+
+    with pytest.raises(
+        ValueError, match=r"daily_bars.*close: expected Float32, got Float64"
+    ):
+        write_consumer_db(bad_bars, sample_metrics_df, sample_tickers_df, db_path)
+
+
+def test_write_consumer_db_validates_optional_weekly_schema(
+    tmp_path: Path,
+    sample_bars_df: pl.DataFrame,
+    sample_metrics_df: pl.DataFrame,
+    sample_tickers_df: pl.DataFrame,
+) -> None:
+    """Optional weekly tables are schema-validated when provided."""
+    db_path = tmp_path / "tickerlake.duckdb"
+    bad_weekly_metrics = sample_metrics_df.with_columns(
+        pl.col("volume_sma_20").cast(pl.Float64)
+    )
+
+    with pytest.raises(
+        ValueError,
+        match=r"weekly_metrics.*volume_sma_20: expected Float32, got Float64",
+    ):
+        write_consumer_db(
+            sample_bars_df,
+            sample_metrics_df,
+            sample_tickers_df,
+            db_path,
+            weekly_metrics=bad_weekly_metrics,
+        )
+
+
+def test_write_consumer_db_validates_optional_monthly_schema(
+    tmp_path: Path,
+    sample_bars_df: pl.DataFrame,
+    sample_metrics_df: pl.DataFrame,
+    sample_tickers_df: pl.DataFrame,
+) -> None:
+    """Optional monthly tables are schema-validated when provided."""
+    db_path = tmp_path / "tickerlake.duckdb"
+    bad_monthly_bars = sample_bars_df.drop("transactions")
+
+    with pytest.raises(
+        ValueError,
+        match=r"monthly_bars.*missing columns: transactions",
+    ):
+        write_consumer_db(
+            sample_bars_df,
+            sample_metrics_df,
+            sample_tickers_df,
+            db_path,
+            monthly_bars=bad_monthly_bars,
+        )
+
+
+def test_write_consumer_db_error_identifies_failing_table(
+    tmp_path: Path,
+    sample_bars_df: pl.DataFrame,
+    sample_metrics_df: pl.DataFrame,
+    sample_tickers_df: pl.DataFrame,
+) -> None:
+    """Schema validation errors identify the failing table name."""
+    db_path = tmp_path / "tickerlake.duckdb"
+    bad_tickers = sample_tickers_df.drop("active")
+
+    with pytest.raises(ValueError, match=r"^tickers schema mismatch"):
+        write_consumer_db(sample_bars_df, sample_metrics_df, bad_tickers, db_path)
+
+
 def test_consumer_query_pattern(
     tmp_path: Path,
     sample_bars_df: pl.DataFrame,


### PR DESCRIPTION
## Summary

- Validate consumer DB DataFrame schemas before writing DuckDB tables.
- Check daily, weekly, and monthly bars/metrics plus ticker data at the load boundary.
- Add focused tests for missing columns, dtype mismatches, optional period tables, and table-specific errors.

## Test plan

- CodeRabbit local review completed once with 0 findings.
- `make check` passes: ruff lint/format, xenon complexity gate, 186 tests, 99.78% coverage.
