### PR TITLE
ci: upload coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   check:
@@ -40,3 +41,10 @@ jobs:
 
       - name: Test with coverage
         run: make test-cov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v7
+        with:
+          files: ./coverage.xml
+          fail_ci_if_error: true
+          use_oidc: true

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ wheels/
 
 # Test/coverage artifacts
 .coverage
+coverage.xml
 htmlcov/
 
 # Sisyphus workflow

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ test:
 	uv run pytest tests/ -x --tb=short
 
 test-cov:
-	uv run pytest tests/ --cov=src/tickerlake --cov-report=html --cov-fail-under=95 --cov-report=term-missing -x
+	uv run pytest tests/ --cov=src/tickerlake --cov-report=html --cov-report=xml --cov-fail-under=95 --cov-report=term-missing -x
 
 lint:
 	uv run ruff check src/ tests/


### PR DESCRIPTION
## Summary

- Add tokenless Codecov upload to CI using OIDC and codecov/codecov-action@v7.
- Emit coverage.xml from the existing coverage target and ignore the generated artifact.
- Fail CI if the Codecov upload fails.

## Test plan

- CodeRabbit local review completed once; valid finding was fixed.
- `make check` passes: ruff lint/format, xenon complexity gate, 181 tests, 99.77% coverage.
