### PR TITLE
feat(fib-zones): weekly IBZ/SMZ screener with k-bar fractal pivots

### DIFF
--- a/src/tickerlake/fib_zones.py
+++ b/src/tickerlake/fib_zones.py
@@ -216,8 +216,8 @@ def _find_most_recent_unswept_leg(
     if pivots.is_empty():
         return None
 
-    low_pivots = (
-        pivots.filter(pl.col("pivot_type") == "low").sort("date", descending=True)
+    low_pivots = pivots.filter(pl.col("pivot_type") == "low").sort(
+        "date", descending=True
     )
     if low_pivots.is_empty():
         return None

--- a/src/tickerlake/fib_zones.py
+++ b/src/tickerlake/fib_zones.py
@@ -8,12 +8,14 @@ and Smart Money Zone (SMZ, 0.786-0.826 retracement) for that leg.
 Algorithm:
     1. Detect k-bar fractal pivots on weekly bars (a bar is a pivot high
        if it's higher than k bars on each side; similarly for pivot low).
-    2. Take the most recent pivot high (latest date).
-    3. Take the most recent pivot low before that pivot high.
-    4. Verify the pivot low hasn't been swept — no bar after the pivot
-       high has traded below the pivot low.
-    5. Verify the leg is "major" — range >= min_leg_pct of the swing high.
-    6. Compute the IBZ/SMZ bands and classify the current price.
+    2. Walk pivot lows from most recent to oldest.
+    3. For each pivot low, find the HIGHEST pivot high that came at
+       least min_bars_between_pivots bars later.
+    4. Verify the leg is "major" — range >= min_leg_pct of the swing high.
+    5. Verify the swing low hasn't been swept — no bar after the swing
+       high has traded below the swing low.
+    6. Return the first valid (most recent) leg found.
+    7. Compute the IBZ/SMZ bands and classify the current price.
 
 Public API:
     WEEKLY_FIB_ZONES_SCHEMA: schema dict for the persisted table.

--- a/tests/test_fib_zones.py
+++ b/tests/test_fib_zones.py
@@ -472,10 +472,40 @@ def test_compute_weekly_fib_zones_all_eligible_ticker_missing_from_bars() -> Non
 
 def test_compute_weekly_fib_zones_all_successful_path() -> None:
     """Eligible ticker with a valid V-shape produces a row in the result."""
-    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0,
-             25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
-    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0,
-            22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
+    highs = [
+        20.0,
+        18.0,
+        15.0,
+        12.0,
+        11.0,
+        10.0,
+        10.0,
+        14.0,
+        20.0,
+        25.0,
+        30.0,
+        28.0,
+        24.0,
+        20.0,
+        14.0,
+    ]
+    lows = [
+        18.0,
+        15.0,
+        12.0,
+        10.0,
+        9.0,
+        8.0,
+        8.0,
+        12.0,
+        18.0,
+        22.0,
+        28.0,
+        25.0,
+        21.0,
+        18.0,
+        12.0,
+    ]
     dates = [datetime.date(2024, 1, 1) + datetime.timedelta(weeks=i) for i in range(15)]
     closes = [(h + lo) / 2 for h, lo in zip(highs, lows, strict=True)]
     bars = pl.DataFrame(

--- a/tests/test_fib_zones.py
+++ b/tests/test_fib_zones.py
@@ -3,7 +3,6 @@
 import datetime
 
 import polars as pl
-import pytest
 
 from tickerlake.fib_zones import (
     WEEKLY_FIB_ZONES_SCHEMA,
@@ -21,11 +20,13 @@ def _make_bars(
     prices_low: list[float],
     start: datetime.date,
 ) -> pl.DataFrame:
-    """Build a polars DataFrame of weekly OHLCV bars from parallel high/low lists."""
+    """Build a polars DataFrame of weekly OHLCV bars from high/low lists."""
     n = len(prices_high)
     assert len(prices_low) == n
     dates = [start + datetime.timedelta(weeks=i) for i in range(n)]
-    closes: list[float] = [(h + l) / 2 for h, l in zip(prices_high, prices_low, strict=True)]
+    closes: list[float] = [
+        (hi + lo) / 2 for hi, lo in zip(prices_high, prices_low, strict=True)
+    ]
     return pl.DataFrame(
         {
             "date": dates,
@@ -49,7 +50,7 @@ def test_classify_zone_bands() -> None:
 
 
 def test_classify_status_live_deep_void() -> None:
-    """Status: live (no post-high low), deep (below SMZ but above low), void (at/below low)."""
+    """Status: live / deep / void based on min_low_after_high vs swing_low/smz_low."""
     assert _classify_status(None, 10.0, 15.0) == "live"
     assert _classify_status(20.0, 10.0, 15.0) == "live"
     assert _classify_status(14.9, 10.0, 15.0) == "deep"
@@ -58,7 +59,7 @@ def test_classify_status_live_deep_void() -> None:
 
 
 def test_levels_and_zones_celh_golden() -> None:
-    """CELH golden test: swing_low=21.10, swing_high=66.74 → IBZ ≈ [30.87, 38.53], SMZ ≈ [29.04, 30.87]."""
+    """CELH golden: swing_low=21.10, swing_high=66.74 → known IBZ/SMZ bands."""
     data = _levels_and_zones(21.10, 66.74)
     assert abs(data["ibz_low"] - 30.87) < 0.05
     assert abs(data["ibz_high"] - 38.53) < 0.05
@@ -74,13 +75,15 @@ def test_compute_fib_zones_empty_bars() -> None:
 
 
 def test_compute_fib_zones_v_shape() -> None:
-    """Clear V-shape: down to 8, up to 30, retrace to 14. Uses k=3 for stable pivots."""
-    # 15 bars: 7 down, 1 turning, 7 up. With k=3, the low at bar 6 and
-    # the high at bar 10 are clear pivots.
-    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0, 25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
-    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0, 22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
+    """Clear V-shape: down to 8, up to 30, retrace to 14 → finds 8→30 leg."""
+    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0,
+             25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
+    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0,
+            22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
     bars = _make_bars(highs, lows, datetime.date(2024, 1, 1))
-    result = compute_fib_zones_for_ticker(bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=2)
+    result = compute_fib_zones_for_ticker(
+        bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=2
+    )
     assert result is not None
     assert result["swing_low"] == 8.0
     assert result["swing_high"] == 30.0
@@ -88,43 +91,47 @@ def test_compute_fib_zones_v_shape() -> None:
 
 def test_compute_fib_zones_min_leg_pct_too_strict() -> None:
     """With min_leg_pct=0.99, no leg passes and the algorithm returns None."""
-    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0, 25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
-    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0, 22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
+    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0,
+             25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
+    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0,
+            22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
     bars = _make_bars(highs, lows, datetime.date(2024, 1, 1))
-    result = compute_fib_zones_for_ticker(bars, k=3, min_leg_pct=0.99, min_bars_between_pivots=2)
-    # No leg has 99% range, so the algorithm returns None
+    result = compute_fib_zones_for_ticker(
+        bars, k=3, min_leg_pct=0.99, min_bars_between_pivots=2
+    )
     assert result is None
 
 
 def test_compute_fib_zones_min_bars_between_pivots_too_strict() -> None:
-    """With min_bars_between_pivots=1000, no leg has a 1000-bar gap and
-    the algorithm returns None."""
-    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0, 25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
-    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0, 22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
+    """min_bars_between_pivots=1000 → no leg has that gap → None."""
+    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0,
+             25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
+    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0,
+            22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
     bars = _make_bars(highs, lows, datetime.date(2024, 1, 1))
-    result = compute_fib_zones_for_ticker(bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=1000)
-    # No leg has a 1000-bar gap between pivots
+    result = compute_fib_zones_for_ticker(
+        bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=1000
+    )
     assert result is None
 
 
 def test_compute_fib_zones_min_bars_between_pivots_relaxed() -> None:
-    """With min_bars_between_pivots=1, the 8→30 leg is accepted."""
-    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0, 25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
-    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0, 22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
+    """min_bars_between_pivots=1 → 8→30 leg accepted."""
+    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0,
+             25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
+    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0,
+            22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
     bars = _make_bars(highs, lows, datetime.date(2024, 1, 1))
-    result = compute_fib_zones_for_ticker(bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=1)
+    result = compute_fib_zones_for_ticker(
+        bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=1
+    )
     assert result is not None
     assert result["swing_low"] == 8.0
     assert result["swing_high"] == 30.0
 
 
 def test_compute_fib_zones_highest_high_not_most_recent() -> None:
-    """The algorithm anchors on the most recent pivot low and pairs it with
-    the HIGHEST pivot high after it. The most recent pivot low is 18 (bar 14),
-    and the highest pivot high after it is 60 (bar 19) — not the most
-    recent minor peak.
-    """
-    # 25 bars: first V (8/30), retrace to 18, second V (20/60), retrace to 38
+    """Anchors on most-recent pivot low, pairs with highest high after it."""
     highs = [
         20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0, 25.0, 30.0,
         28.0, 25.0, 22.0, 20.0, 22.0, 30.0, 40.0, 50.0, 60.0, 58.0,
@@ -136,20 +143,24 @@ def test_compute_fib_zones_highest_high_not_most_recent() -> None:
         52.0, 48.0, 42.0, 38.0,
     ]
     bars = _make_bars(highs, lows, datetime.date(2024, 1, 1))
-    result = compute_fib_zones_for_ticker(bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=3)
+    result = compute_fib_zones_for_ticker(
+        bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=3
+    )
     assert result is not None
-    # The most recent pivot low is 18 (bar 14). The highest pivot high
-    # after it is 60 (bar 19). The algorithm pairs 18 with 60.
     assert result["swing_low"] == 18.0
     assert result["swing_high"] == 60.0
 
 
 def test_compute_fib_zones_schema_compliance() -> None:
     """Returned dict has all WEEKLY_FIB_ZONES_SCHEMA keys."""
-    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0, 25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
-    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0, 22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
+    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0,
+             25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
+    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0,
+            22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
     bars = _make_bars(highs, lows, datetime.date(2024, 1, 1))
-    result = compute_fib_zones_for_ticker(bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=2)
+    result = compute_fib_zones_for_ticker(
+        bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=2
+    )
     assert result is not None
     for key in WEEKLY_FIB_ZONES_SCHEMA:
         assert key in result, f"missing key: {key}"
@@ -171,19 +182,18 @@ def test_compute_weekly_fib_zones_all_empty_input() -> None:
 
 def test_compute_weekly_fib_zones_all_filters_eligible() -> None:
     """Only eligible tickers are processed."""
-    bars_rows = []
-    for ticker in ("AAA", "BBB", "CCC"):
-        for i in range(30):
-            bars_rows.append(
-                {
-                    "ticker": ticker,
-                    "date": datetime.date(2024, 1, 1) + datetime.timedelta(weeks=i),
-                    "high": 20.0 + i,
-                    "low": 18.0 + i,
-                    "close": 19.0 + i,
-                    "volume": 1_000_000.0,
-                }
-            )
+    bars_rows = [
+        {
+            "ticker": ticker,
+            "date": datetime.date(2024, 1, 1) + datetime.timedelta(weeks=i),
+            "high": 20.0 + i,
+            "low": 18.0 + i,
+            "close": 19.0 + i,
+            "volume": 1_000_000.0,
+        }
+        for ticker in ("AAA", "BBB", "CCC")
+        for i in range(30)
+    ]
     df = pl.DataFrame(bars_rows, schema_overrides={"date": pl.Date})
     result = compute_weekly_fib_zones_all(df, eligible_tickers={"AAA", "CCC"})
     tickers = set(result["ticker"].to_list()) if not result.is_empty() else set()

--- a/tests/test_fib_zones.py
+++ b/tests/test_fib_zones.py
@@ -76,10 +76,40 @@ def test_compute_fib_zones_empty_bars() -> None:
 
 def test_compute_fib_zones_v_shape() -> None:
     """Clear V-shape: down to 8, up to 30, retrace to 14 → finds 8→30 leg."""
-    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0,
-             25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
-    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0,
-            22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
+    highs = [
+        20.0,
+        18.0,
+        15.0,
+        12.0,
+        11.0,
+        10.0,
+        10.0,
+        14.0,
+        20.0,
+        25.0,
+        30.0,
+        28.0,
+        24.0,
+        20.0,
+        14.0,
+    ]
+    lows = [
+        18.0,
+        15.0,
+        12.0,
+        10.0,
+        9.0,
+        8.0,
+        8.0,
+        12.0,
+        18.0,
+        22.0,
+        28.0,
+        25.0,
+        21.0,
+        18.0,
+        12.0,
+    ]
     bars = _make_bars(highs, lows, datetime.date(2024, 1, 1))
     result = compute_fib_zones_for_ticker(
         bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=2
@@ -91,10 +121,40 @@ def test_compute_fib_zones_v_shape() -> None:
 
 def test_compute_fib_zones_min_leg_pct_too_strict() -> None:
     """With min_leg_pct=0.99, no leg passes and the algorithm returns None."""
-    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0,
-             25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
-    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0,
-            22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
+    highs = [
+        20.0,
+        18.0,
+        15.0,
+        12.0,
+        11.0,
+        10.0,
+        10.0,
+        14.0,
+        20.0,
+        25.0,
+        30.0,
+        28.0,
+        24.0,
+        20.0,
+        14.0,
+    ]
+    lows = [
+        18.0,
+        15.0,
+        12.0,
+        10.0,
+        9.0,
+        8.0,
+        8.0,
+        12.0,
+        18.0,
+        22.0,
+        28.0,
+        25.0,
+        21.0,
+        18.0,
+        12.0,
+    ]
     bars = _make_bars(highs, lows, datetime.date(2024, 1, 1))
     result = compute_fib_zones_for_ticker(
         bars, k=3, min_leg_pct=0.99, min_bars_between_pivots=2
@@ -104,10 +164,40 @@ def test_compute_fib_zones_min_leg_pct_too_strict() -> None:
 
 def test_compute_fib_zones_min_bars_between_pivots_too_strict() -> None:
     """min_bars_between_pivots=1000 → no leg has that gap → None."""
-    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0,
-             25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
-    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0,
-            22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
+    highs = [
+        20.0,
+        18.0,
+        15.0,
+        12.0,
+        11.0,
+        10.0,
+        10.0,
+        14.0,
+        20.0,
+        25.0,
+        30.0,
+        28.0,
+        24.0,
+        20.0,
+        14.0,
+    ]
+    lows = [
+        18.0,
+        15.0,
+        12.0,
+        10.0,
+        9.0,
+        8.0,
+        8.0,
+        12.0,
+        18.0,
+        22.0,
+        28.0,
+        25.0,
+        21.0,
+        18.0,
+        12.0,
+    ]
     bars = _make_bars(highs, lows, datetime.date(2024, 1, 1))
     result = compute_fib_zones_for_ticker(
         bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=1000
@@ -117,10 +207,40 @@ def test_compute_fib_zones_min_bars_between_pivots_too_strict() -> None:
 
 def test_compute_fib_zones_min_bars_between_pivots_relaxed() -> None:
     """min_bars_between_pivots=1 → 8→30 leg accepted."""
-    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0,
-             25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
-    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0,
-            22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
+    highs = [
+        20.0,
+        18.0,
+        15.0,
+        12.0,
+        11.0,
+        10.0,
+        10.0,
+        14.0,
+        20.0,
+        25.0,
+        30.0,
+        28.0,
+        24.0,
+        20.0,
+        14.0,
+    ]
+    lows = [
+        18.0,
+        15.0,
+        12.0,
+        10.0,
+        9.0,
+        8.0,
+        8.0,
+        12.0,
+        18.0,
+        22.0,
+        28.0,
+        25.0,
+        21.0,
+        18.0,
+        12.0,
+    ]
     bars = _make_bars(highs, lows, datetime.date(2024, 1, 1))
     result = compute_fib_zones_for_ticker(
         bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=1
@@ -133,14 +253,58 @@ def test_compute_fib_zones_min_bars_between_pivots_relaxed() -> None:
 def test_compute_fib_zones_highest_high_not_most_recent() -> None:
     """Anchors on most-recent pivot low, pairs with highest high after it."""
     highs = [
-        20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0, 25.0, 30.0,
-        28.0, 25.0, 22.0, 20.0, 22.0, 30.0, 40.0, 50.0, 60.0, 58.0,
-        55.0, 50.0, 45.0, 40.0,
+        20.0,
+        18.0,
+        15.0,
+        12.0,
+        11.0,
+        10.0,
+        10.0,
+        14.0,
+        20.0,
+        25.0,
+        30.0,
+        28.0,
+        25.0,
+        22.0,
+        20.0,
+        22.0,
+        30.0,
+        40.0,
+        50.0,
+        60.0,
+        58.0,
+        55.0,
+        50.0,
+        45.0,
+        40.0,
     ]
     lows = [
-        18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0, 22.0, 28.0,
-        25.0, 22.0, 20.0, 18.0, 20.0, 28.0, 38.0, 48.0, 58.0, 55.0,
-        52.0, 48.0, 42.0, 38.0,
+        18.0,
+        15.0,
+        12.0,
+        10.0,
+        9.0,
+        8.0,
+        8.0,
+        12.0,
+        18.0,
+        22.0,
+        28.0,
+        25.0,
+        22.0,
+        20.0,
+        18.0,
+        20.0,
+        28.0,
+        38.0,
+        48.0,
+        58.0,
+        55.0,
+        52.0,
+        48.0,
+        42.0,
+        38.0,
     ]
     bars = _make_bars(highs, lows, datetime.date(2024, 1, 1))
     result = compute_fib_zones_for_ticker(
@@ -153,10 +317,40 @@ def test_compute_fib_zones_highest_high_not_most_recent() -> None:
 
 def test_compute_fib_zones_schema_compliance() -> None:
     """Returned dict has all WEEKLY_FIB_ZONES_SCHEMA keys."""
-    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0,
-             25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
-    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0,
-            22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
+    highs = [
+        20.0,
+        18.0,
+        15.0,
+        12.0,
+        11.0,
+        10.0,
+        10.0,
+        14.0,
+        20.0,
+        25.0,
+        30.0,
+        28.0,
+        24.0,
+        20.0,
+        14.0,
+    ]
+    lows = [
+        18.0,
+        15.0,
+        12.0,
+        10.0,
+        9.0,
+        8.0,
+        8.0,
+        12.0,
+        18.0,
+        22.0,
+        28.0,
+        25.0,
+        21.0,
+        18.0,
+        12.0,
+    ]
     bars = _make_bars(highs, lows, datetime.date(2024, 1, 1))
     result = compute_fib_zones_for_ticker(
         bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=2

--- a/tests/test_fib_zones.py
+++ b/tests/test_fib_zones.py
@@ -8,8 +8,11 @@ from tickerlake.fib_zones import (
     WEEKLY_FIB_ZONES_SCHEMA,
     _classify_status,
     _classify_zone,
+    _find_bar_index,
     _find_most_recent_unswept_leg,
+    _is_swept,
     _levels_and_zones,
+    _try_leg_for_low,
     compute_fib_zones_for_ticker,
     compute_weekly_fib_zones_all,
 )
@@ -401,3 +404,94 @@ def test_find_most_recent_unswept_leg_empty_pivots() -> None:
         schema={"date": pl.Date, "pivot_type": pl.Utf8, "price": pl.Float64}
     )
     assert _find_most_recent_unswept_leg(pivots, [], 0.20) is None
+
+
+def test_find_most_recent_unswept_leg_no_low_pivots() -> None:
+    """Pivots with only highs → None (no lows to anchor on)."""
+    pivots = pl.DataFrame(
+        {
+            "date": [datetime.date(2024, 1, 1), datetime.date(2024, 2, 1)],
+            "pivot_type": ["high", "high"],
+            "price": [10.0, 20.0],
+        },
+        schema_overrides={"date": pl.Date},
+    )
+    assert _find_most_recent_unswept_leg(pivots, [], 0.20) is None
+
+
+def test_find_bar_index_not_found() -> None:
+    """_find_bar_index returns None when the date is not in the bars."""
+    bars = [{"date": datetime.date(2024, 1, 1), "high": 10.0, "low": 8.0}]
+    assert _find_bar_index(bars, datetime.date(2024, 6, 1)) is None
+
+
+def test_is_swept_true() -> None:
+    """_is_swept returns True when a bar after start_idx has a low below threshold."""
+    bars = [
+        {"date": datetime.date(2024, 1, 1), "high": 20.0, "low": 10.0},
+        {"date": datetime.date(2024, 2, 1), "high": 18.0, "low": 8.0},  # below 10
+        {"date": datetime.date(2024, 3, 1), "high": 15.0, "low": 9.0},
+    ]
+    assert _is_swept(bars, 0, 10.0) is True
+
+
+def test_try_leg_for_low_no_candidate_highs() -> None:
+    """_try_leg_for_low returns None when no pivot highs exist after the low."""
+    low_row = {
+        "date": datetime.date(2024, 1, 1),
+        "price": 10.0,
+    }
+    pivots = pl.DataFrame(
+        {
+            "date": [datetime.date(2024, 1, 1)],
+            "pivot_type": ["low"],
+            "price": [10.0],
+        },
+        schema_overrides={"date": pl.Date},
+    )
+    bars = [{"date": datetime.date(2024, 1, 1), "high": 10.0, "low": 10.0}]
+    assert _try_leg_for_low(low_row, pivots, bars, 0.20, 2) is None
+
+
+def test_compute_weekly_fib_zones_all_eligible_ticker_missing_from_bars() -> None:
+    """Eligible tickers not present in bars are silently skipped."""
+    bars = pl.DataFrame(
+        {
+            "ticker": ["AAA"],
+            "date": [datetime.date(2024, 1, 1)],
+            "high": [20.0],
+            "low": [18.0],
+            "close": [19.0],
+        },
+        schema_overrides={"date": pl.Date},
+    )
+    result = compute_weekly_fib_zones_all(bars, eligible_tickers={"AAA", "ZZZ"})
+    # ZZZ not in bars — skipped silently. AAA has only 1 bar, no pivots.
+    assert result.is_empty()
+
+
+def test_compute_weekly_fib_zones_all_successful_path() -> None:
+    """Eligible ticker with a valid V-shape produces a row in the result."""
+    highs = [20.0, 18.0, 15.0, 12.0, 11.0, 10.0, 10.0, 14.0, 20.0,
+             25.0, 30.0, 28.0, 24.0, 20.0, 14.0]
+    lows = [18.0, 15.0, 12.0, 10.0, 9.0, 8.0, 8.0, 12.0, 18.0,
+            22.0, 28.0, 25.0, 21.0, 18.0, 12.0]
+    dates = [datetime.date(2024, 1, 1) + datetime.timedelta(weeks=i) for i in range(15)]
+    closes = [(h + lo) / 2 for h, lo in zip(highs, lows, strict=True)]
+    bars = pl.DataFrame(
+        {
+            "ticker": ["AAA"] * 15,
+            "date": dates,
+            "open": closes,
+            "high": highs,
+            "low": lows,
+            "close": closes,
+            "volume": [1_000_000.0] * 15,
+        },
+        schema_overrides={"date": pl.Date},
+    )
+    result = compute_weekly_fib_zones_all(
+        bars, eligible_tickers={"AAA"}, k=3, min_leg_pct=0.20
+    )
+    assert not result.is_empty()
+    assert result["ticker"][0] == "AAA"


### PR DESCRIPTION
## Summary

Adds a weekly-timeframe Fibonacci-retracement screener to tickerlake. For every liquid ticker, identifies the most recent unswept major swing low → swing high leg on weekly bars, computes the IBZ (0.618-0.786) and SMZ (0.786-0.826) zones, and persists one row per ticker to a new `weekly_fib_zones` table in `tickerlake.duckdb`.

## Algorithm

1. **Pivot detection**: k-bar fractal pivots (k=4, project default) — a bar is a pivot high if it's higher than k bars on each side; similarly for pivot low. Produces clean swing points matching the kind shown in TradingView's fib retracement drawings.

2. **Leg selection**: anchors on the **most recent pivot low** (walking back in time) and pairs it with the **highest pivot high** that came at least `min_bars_between_pivots` (5 weeks) later — not just the most recent high. This matches the "draw the fib from the most recent major swing low to the major swing high" mental model.

3. **Validation**:
   - Range >= 20% of swing high (the "major" qualifier)
   - Swing low hasn't been swept (no bar after the swing high has traded below it)

## Screens supported

- `in_smz` — best risk/reward ratio (tighter zone, closer to swing low stop)
- `in_ibz` — next best
- `below_smz` — between the SMZ low and the pivot low (more risk, more reward)
- `above_ibz` — still making new highs (watch level, not actionable)
- `all` — actionable zones only (excludes void degrees)

## CLI

```
tickerlake fib-zones compute [--output-dir DIR]
tickerlake fib-zones screen [--zone {in_smz|in_ibz|below_smz|above_ibz|all}] [--limit N] [--output-dir DIR]
```

## Liquidity filter

Ticker universe: those whose latest `weekly_metrics` row has `volume_sma_20 >= 1,000,000` (~4,842 tickers).

## Validation

- 251 tests pass at 99% coverage (`fib_zones.py` at 91%)
- `tickerlake fib-zones compute` ran successfully: 3,697 tickers written
  - 569 in_ibz, 142 in_smz, 362 below_smz, 2,624 above_ibz, 7 void
- `tickerlake fib-zones screen --zone in_smz` returns 142 matches

## Validated against user's charts

Multiple tickers spot-checked against real stock charts (SOFI, AFRM, ACHR, ACM, AGI, AA, AAON, AAUC, AAAU, ABAT, ABLV, ARKB, BITB, RING, etc.) — all correct. The algorithm evolution was driven by user feedback: pivots too close in time (added min_bars_between_pivots=5), wrong high selected (changed to "highest high after most-recent low"), and stock filters (<$5 excluded, liquidity floor).