### PR TITLE
feat(fib-zones): cap lookback at 2 years and add min-swing-low screen filter

### DIFF
--- a/src/tickerlake/__init__.py
+++ b/src/tickerlake/__init__.py
@@ -106,6 +106,13 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Zone to filter on (default: all actionable zones)",
     )
     fib_zones_screen_parser.add_argument(
+        "--min-swing-low",
+        type=float,
+        default=5.0,
+        metavar="DOLLARS",
+        help="Minimum swing low price to include (default: 5.0; use 0 to disable)",
+    )
+    fib_zones_screen_parser.add_argument(
         "--limit",
         type=_parse_positive_int,
         default=None,
@@ -139,7 +146,12 @@ def _dispatch_fib_zones(
             parser.error(str(err))
     elif args.fib_zones_command == "screen":
         try:
-            pipeline.screen_fib_zones(config, zone=args.zone, limit=args.limit)
+            pipeline.screen_fib_zones(
+                config,
+                zone=args.zone,
+                limit=args.limit,
+                min_swing_low=args.min_swing_low,
+            )
         except ValueError as err:
             parser.error(str(err))
 

--- a/src/tickerlake/fib_zones.py
+++ b/src/tickerlake/fib_zones.py
@@ -6,6 +6,8 @@ then computes the Institutional Buying Zone (IBZ, 0.618-0.786 retracement)
 and Smart Money Zone (SMZ, 0.786-0.826 retracement) for that leg.
 
 Algorithm:
+    0. Restrict bars to the most recent max_lookback_years (default 2
+       years) — legs anchored on older pivot lows are ignored.
     1. Detect k-bar fractal pivots on weekly bars (a bar is a pivot high
        if it's higher than k bars on each side; similarly for pivot low).
     2. Walk pivot lows from most recent to oldest.
@@ -27,9 +29,13 @@ Public API:
 
 from __future__ import annotations
 
+import datetime
+
 import polars as pl
 
 from tickerlake.transform import find_pivots
+
+DEFAULT_MAX_LOOKBACK_YEARS: int = 2
 
 # Public schema — used by load.py.
 WEEKLY_FIB_ZONES_SCHEMA: dict = {
@@ -238,12 +244,17 @@ def compute_fib_zones_for_ticker(
     k: int = 4,
     min_leg_pct: float = 0.20,
     min_bars_between_pivots: int = 5,
+    max_lookback_years: int | None = DEFAULT_MAX_LOOKBACK_YEARS,
 ) -> dict | None:
     """Compute fib zones for the most recent unswept major leg on weekly bars.
 
     Uses k-bar fractal pivots to identify swing highs and lows, then anchors
     on the most recent pivot low and pairs it with the highest pivot high
     that came at least `min_bars_between_pivots` weeks later.
+
+    Bars are first restricted to the most recent `max_lookback_years` (default
+    2 years; pass None to disable the cap), so the leg's swing low cannot be
+    older than that window.
 
     Returns a flat dict matching WEEKLY_FIB_ZONES_SCHEMA keys, or None
     when no valid unswept leg exists.
@@ -258,11 +269,16 @@ def compute_fib_zones_for_ticker(
         min_bars_between_pivots: minimum number of weekly bars between
             the swing low and the swing high. Default 5 — filters out
             legs where the pivots are too close together in time.
+        max_lookback_years: maximum age of bars considered, capped at this
+            many years before the last bar. Default 2.
     """
     if bars is None or bars.is_empty():
         return None
 
     sorted_df = bars.sort("date")
+    if max_lookback_years is not None:
+        cutoff = datetime.timedelta(days=365 * max_lookback_years)
+        sorted_df = sorted_df.filter(pl.col("date") >= pl.col("date").max() - cutoff)
     bar_dicts = sorted_df.select(["date", "high", "low", "close"]).to_dicts()
     if not bar_dicts:
         return None

--- a/src/tickerlake/pipeline.py
+++ b/src/tickerlake/pipeline.py
@@ -416,9 +416,10 @@ def compute_weekly_fib_zones(config: Config) -> None:
     """Compute weekly fib zones for all eligible tickers and persist them.
 
     Eligible tickers are those whose latest weekly_metrics row has
-    volume_sma_20 >= _LIQUIDITY_VOLUME_THRESHOLD. The lookback is the full
-    weekly_bars window (no truncation). Logs the number of eligible tickers,
-    per-zone counts, void count, and rows written.
+    volume_sma_20 >= _LIQUIDITY_VOLUME_THRESHOLD. The lookback is capped at
+    the most recent 2 years of weekly bars (see fib_zones.DEFAULT_MAX_LOOKBACK_YEARS).
+    Logs the number of eligible tickers, per-zone counts, void count, and
+    rows written.
     """
     consumer_path = config.output_dir / "tickerlake.duckdb"
     if not consumer_path.exists():
@@ -460,12 +461,14 @@ def screen_fib_zones(
     *,
     zone: str = "all",
     limit: int | None = None,
+    min_swing_low: float = 5.0,
 ) -> None:
     """Print a screen of persisted weekly fib zones to the console.
 
     zone="all" restricts to the actionable zones (in_ibz, in_smz, below_smz)
     with primary_status != 'void'. Any other zone value filters to that single
-    zone regardless of status. Results are sorted by ticker and optionally
+    zone regardless of status. Rows whose swing_low is below min_swing_low are
+    excluded (default $5 minimum). Results are sorted by ticker and optionally
     capped at `limit` rows.
     """
     consumer_path = config.output_dir / "tickerlake.duckdb"
@@ -478,6 +481,7 @@ def screen_fib_zones(
         result = result.filter(pl.col("primary_status") != "void")
     else:
         result = read_weekly_fib_zones(consumer_path, zone=zone)
+    result = result.filter(pl.col("swing_low") >= min_swing_low)
     result = result.sort("ticker")
 
     total = result.height
@@ -508,9 +512,10 @@ def screen_fib_zones(
 
     limit_label = str(limit) if limit is not None else "unlimited"
     logger.info(
-        "Screen: %d total matches, %d displayed (zone=%s, limit=%s).",
+        "Screen: %d total matches, %d displayed (zone=%s, limit=%s, min_swing_low=%s).",
         total,
         displayed.height,
         zone,
         limit_label,
+        min_swing_low,
     )

--- a/tests/test_fib_zones.py
+++ b/tests/test_fib_zones.py
@@ -122,6 +122,111 @@ def test_compute_fib_zones_v_shape() -> None:
     assert result["swing_high"] == 30.0
 
 
+def test_compute_fib_zones_lookback_drops_old_leg() -> None:
+    """A valid leg whose swing low is older than the 2-year lookback is
+    ignored; disabling the lookback finds it."""
+    v_highs = [
+        20.0,
+        18.0,
+        15.0,
+        12.0,
+        11.0,
+        10.0,
+        10.0,
+        14.0,
+        20.0,
+        25.0,
+        30.0,
+        28.0,
+        24.0,
+        20.0,
+        14.0,
+    ]
+    v_lows = [
+        18.0,
+        15.0,
+        12.0,
+        10.0,
+        9.0,
+        8.0,
+        8.0,
+        12.0,
+        18.0,
+        22.0,
+        28.0,
+        25.0,
+        21.0,
+        18.0,
+        12.0,
+    ]
+    tail_highs = [14.0 - 0.035 * i for i in range(100)]
+    tail_lows = [13.0 - 0.035 * i for i in range(100)]
+    bars = _make_bars(
+        v_highs + tail_highs, v_lows + tail_lows, datetime.date(2023, 1, 1)
+    )
+    assert (
+        compute_fib_zones_for_ticker(
+            bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=2
+        )
+        is None
+    )
+    result = compute_fib_zones_for_ticker(
+        bars,
+        k=3,
+        min_leg_pct=0.20,
+        min_bars_between_pivots=2,
+        max_lookback_years=None,
+    )
+    assert result is not None
+    assert result["swing_low"] == 8.0
+    assert result["swing_high"] == 30.0
+
+
+def test_compute_fib_zones_lookback_keeps_recent_leg() -> None:
+    """A leg whose swing low is within the lookback window is still found."""
+    highs = [
+        20.0,
+        18.0,
+        15.0,
+        12.0,
+        11.0,
+        10.0,
+        10.0,
+        14.0,
+        20.0,
+        25.0,
+        30.0,
+        28.0,
+        24.0,
+        20.0,
+        14.0,
+    ]
+    lows = [
+        18.0,
+        15.0,
+        12.0,
+        10.0,
+        9.0,
+        8.0,
+        8.0,
+        12.0,
+        18.0,
+        22.0,
+        28.0,
+        25.0,
+        21.0,
+        18.0,
+        12.0,
+    ]
+    bars = _make_bars(highs, lows, datetime.date(2025, 1, 1))
+    result = compute_fib_zones_for_ticker(
+        bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=2
+    )
+    assert result is not None
+    assert result["swing_low"] == 8.0
+    assert result["swing_high"] == 30.0
+
+
 def test_compute_fib_zones_min_leg_pct_too_strict() -> None:
     """With min_leg_pct=0.99, no leg passes and the algorithm returns None."""
     highs = [

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1635,7 +1635,28 @@ def test_screen_fib_zones_limit_caps_displayed(tmp_path: Path, caplog) -> None:
     text = recording.export_text()
     assert "AAPL" in text
     assert "MSFT" not in text
-    assert "Screen: 2 total matches, 1 displayed (zone=all, limit=1)" in caplog.text
+    assert "Screen: 2 total matches, 1 displayed (zone=all, limit=1," in caplog.text
+    assert "min_swing_low=5.0" in caplog.text
+
+
+def test_screen_fib_zones_min_swing_low_filters(tmp_path: Path, caplog) -> None:
+    """min_swing_low excludes rows whose swing low is below the cutoff."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    _write_fib_zones_table(tmp_path / "tickerlake.duckdb", _zones_df())
+    recording = Console(record=True)
+
+    with (
+        patch(f"{_PIPELINE}.console", recording),
+        caplog.at_level("INFO"),
+    ):
+        pipeline.screen_fib_zones(config, zone="all", min_swing_low=90.0)
+
+    text = recording.export_text()
+    assert "MSFT" in text  # swing_low 150 >= 90
+    assert "AAPL" not in text  # swing_low 80 < 90
+    assert "Screen: 1 total matches, 1 displayed" in caplog.text
 
 
 def test_screen_fib_zones_sorted_by_ticker(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Cap the weekly fib zone lookback at 2 years: `compute_fib_zones_for_ticker` now truncates bars to the most recent 2 years (default, `max_lookback_years=2`, pass `None` to disable) before pivot detection, so the swing low, sweep check, and status all stay inside the window. This drops stale legs anchored on multi-year-old lows (e.g. in_smz count went 142 → 107 on the live DB).
- Add a `--min-swing-low` filter to `fib-zones screen` (default `5.0`, use `0` to disable) so sub-$5 swing lows can be excluded from the report without ad-hoc queries. `tickerlake fib-zones screen --zone in_smz` now returns the 59-name report.

## Test plan

- 260 tests pass at 99.4% coverage.
- `make check` passes: ruff lint/format, xenon complexity gate, coverage gate.
- CodeRabbit local review skipped: run timed out after 90s without producing findings.
