### PR TITLE
feat(transform): label weekly bars with their week-start Monday

### DIFF
--- a/src/tickerlake/transform.py
+++ b/src/tickerlake/transform.py
@@ -180,18 +180,24 @@ def compute_metrics(bars: pl.DataFrame) -> pl.DataFrame:
 
 
 def _aggregate_to_period(bars: pl.DataFrame, every: str) -> pl.DataFrame:
-    """Aggregate daily OHLCV bars into calendar periods per ticker."""
+    """Aggregate daily OHLCV bars into calendar periods per ticker.
+
+    Weekly bars are labeled with the Monday that starts their week (the
+    week-start convention used by most charting platforms); monthly bars
+    with the last trading day of the month.
+    """
     if bars.is_empty():
         return pl.DataFrame(schema=DAILY_AGGS_SCHEMA)
 
-    return (
+    is_weekly = every == "1w"
+    aggregated = (
         bars.sort(["ticker", "date"])
         .group_by_dynamic(
             "date",
             every=every,
             period=every,
             group_by="ticker",
-            start_by="monday" if every == "1w" else "window",
+            start_by="monday" if is_weekly else "window",
         )
         .agg(
             [
@@ -211,7 +217,15 @@ def _aggregate_to_period(bars: pl.DataFrame, every: str) -> pl.DataFrame:
                 pl.col("date").max().alias("period_date"),
             ]
         )
-        .drop("date")
+    )
+    if is_weekly:
+        return (
+            aggregated.drop("period_date")
+            .sort(["ticker", "date"])
+            .select(list(DAILY_AGGS_SCHEMA.keys()))
+        )
+    return (
+        aggregated.drop("date")
         .rename({"period_date": "date"})
         .sort(["ticker", "date"])
         .select(list(DAILY_AGGS_SCHEMA.keys()))
@@ -221,8 +235,8 @@ def _aggregate_to_period(bars: pl.DataFrame, every: str) -> pl.DataFrame:
 def aggregate_to_weekly(bars: pl.DataFrame) -> pl.DataFrame:
     """Aggregate daily OHLCV bars into weekly bars per ticker.
 
-    Weekly grouping is by calendar week. The output date is the actual last
-    trading day present in that ticker-week.
+    Weekly grouping is by calendar week (Monday-start). The output date is
+    the Monday that starts the ticker-week.
     """
     return _aggregate_to_period(bars, "1w")
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -196,9 +196,9 @@ class TestAggregateToWeekly:
         ) / 6000.0
         assert row["vwap"] == pytest.approx(expected_vwap)
         assert row["transactions"] == 60
-        assert row["date"] == datetime.date(2024, 1, 12)
+        assert row["date"] == datetime.date(2024, 1, 8)
 
-    def test_date_is_last_trading_day(self):
+    def test_date_is_week_start_monday(self):
         bars = make_bars(
             [
                 {
@@ -250,13 +250,13 @@ class TestAggregateToWeekly:
 
         row = aggregate_to_weekly(bars).row(0, named=True)
 
-        assert row["date"] == datetime.date(2024, 1, 11)
+        assert row["date"] == datetime.date(2024, 1, 8)
 
-    def test_partial_week_included(self):
+    def test_partial_midweek_start_labeled_monday(self):
         bars = make_bars(
             [
                 {
-                    "date": datetime.date(2024, 1, 8),
+                    "date": datetime.date(2024, 1, 16),
                     "ticker": "AAPL",
                     "open": 100.0,
                     "high": 101.0,
@@ -267,7 +267,7 @@ class TestAggregateToWeekly:
                     "transactions": 10,
                 },
                 {
-                    "date": datetime.date(2024, 1, 9),
+                    "date": datetime.date(2024, 1, 17),
                     "ticker": "AAPL",
                     "open": 101.0,
                     "high": 102.0,
@@ -278,7 +278,7 @@ class TestAggregateToWeekly:
                     "transactions": 11,
                 },
                 {
-                    "date": datetime.date(2024, 1, 10),
+                    "date": datetime.date(2024, 1, 18),
                     "ticker": "AAPL",
                     "open": 102.0,
                     "high": 103.0,
@@ -293,7 +293,7 @@ class TestAggregateToWeekly:
 
         row = aggregate_to_weekly(bars).row(0, named=True)
 
-        assert row["date"] == datetime.date(2024, 1, 10)
+        assert row["date"] == datetime.date(2024, 1, 15)
         assert row["volume"] == pytest.approx(3300.0)
 
     def test_single_day_week(self):
@@ -497,7 +497,7 @@ def test_bars_for_timeframe_daily_weekly_monthly():
     monthly = bars_for_timeframe(bars, "monthly")
 
     assert daily["date"].to_list() == sorted(bars["date"].to_list())
-    assert weekly["date"].to_list() == [datetime.date(2024, 2, 3)]
+    assert weekly["date"].to_list() == [datetime.date(2024, 1, 29)]
     assert monthly["date"].to_list() == [
         datetime.date(2024, 1, 31),
         datetime.date(2024, 2, 3),


### PR DESCRIPTION
## Summary

- Weekly bars are now labeled with the Monday that starts their week instead of the week's last trading day. The weekly aggregation buckets always started on Mondays (`group_by_dynamic(..., start_by="monday")`), but the code threw the Monday bucket key away and emitted `date.max()` — the Friday (or whatever the last trading day was). Keeping the bucket key means swing-low/high dates, `as_of_date`, and the pivot screen all report the week-start Monday, matching the convention on most charting platforms.
- Monthly bars are unchanged: they keep the last trading day of the month.
- Rebuilt the consumer DB and fib zones on the live data: zone counts are identical (494 `in_ibz`, 107 `in_smz`), only the dates shifted.

## Test plan

- 260 tests pass at 99.4% coverage; `make check` passes (ruff lint/format, xenon complexity, coverage gate).
- Added a mid-week-start fixture asserting a Tuesday/Wednesday-start week still labels the Monday (CodeRabbit suggestion).
- CodeRabbit local review: completed with 1 minor finding (test coverage for mid-week starts), addressed.
