### PR TITLE
feat(fair-value-bands): add confirmed overlays

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,12 +14,13 @@ US equity market ETL pipeline. Pulls OHLCV bars, splits, and ticker metadata fro
 ```
 tickerlake/
 ├── src/tickerlake/
-│   ├── __init__.py     # CLI entry point (argparse, 3 subcommands)
+│   ├── __init__.py     # CLI entry point (argparse subcommands)
 │   ├── config.py       # Config dataclass, env var validation
 │   ├── client.py       # Thin wrapper around massive.RESTClient
 │   ├── calendar.py     # NYSE trading day calendar via exchange_calendars
 │   ├── extract.py      # API objects -> polars DataFrames (schema-driven)
 │   ├── transform.py    # Split adjustment, ticker filtering, SMA/ATR metrics
+│   ├── fair_value_bands.py # Daily/weekly/monthly Fair Value Bands transform
 │   ├── load.py         # DuckDB I/O via temporary parquet intermediaries
 │   └── pipeline.py     # Orchestrates E->T->L for backfill/update/info
 ├── tests/              # 1:1 test files per module + conftest fixtures
@@ -84,6 +85,8 @@ uv run ty check src/                             # Type check
 
 - **MASSIVE_API_KEY** env var is required for Massive-backed commands (`backfill`, `update`, `compact`). `Config.__post_init__` is permissive (may be empty for read-only commands like `pivots` and `info`); enforcement happens at the command boundary via `pipeline._require_api_key` (raises `ValueError("MASSIVE_API_KEY environment variable is required")` on empty key) and in `MassiveClient.__init__` as defense in depth.
 - **Two DuckDB files**: `raw.duckdb` (raw bars) and `tickerlake.duckdb` (adjusted bars + metrics + tickers)
-- **Consumer DB tables**: `daily_bars`, `daily_metrics`, `tickers`, `weekly_bars`, `weekly_metrics`, `monthly_bars`, `monthly_metrics`
+- **Consumer DB tables**: `daily_bars`, `daily_metrics`, `tickers`, `weekly_bars`, `weekly_metrics`, `monthly_bars`, `monthly_metrics`, `daily_fair_value_bands`, `weekly_fair_value_bands`, `monthly_fair_value_bands`
+- **Fair Value Bands tables**: `monthly_fair_value_bands` stores native monthly bands, `weekly_fair_value_bands` stores confirmed monthly bands overlaid on weekly bars, and `daily_fair_value_bands` stores confirmed weekly bands overlaid on daily bars.
 - **Update is incremental and revision-aware**: delegates to the backfill sequence (`_run_backfill(config, bars_start=...)`) with the bars-fetch start narrowed to a trailing `_REVISION_WINDOW_DAYS`-day window of already-cached dates (fetch-then-swap: fetch first, then delete+replace only the dates Massive actually returned data for in that window), so revisions Massive makes to already-published bars (up to ~5 trading days back) get picked up on the next run. Splits/tickers extraction always covers the full `config.start_date`-`config.end_date` range regardless. Consumer db is always fully rebuilt from raw.duckdb.
+- **Fair Value Bands**: the overlay chain is daily <- weekly <- monthly, with weekly values available the next Monday, monthly values available the first day of the next calendar month, and backward as-of matching with no future source values; `tickerlake fair-value-bands compute --timeframe {daily,weekly,monthly}` and `tickerlake fair-value-bands screen --timeframe {daily,weekly,monthly}` select the display timeframe and default to monthly.
 - **Python 3.14 only**: `requires-python = ">=3.14,<3.15"` -- uses modern syntax throughout

--- a/src/tickerlake/__init__.py
+++ b/src/tickerlake/__init__.py
@@ -120,6 +120,70 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     fib_zones_screen_parser.add_argument("--output-dir", type=Path, metavar="DIR")
 
+    fair_value_bands_parser = subparsers.add_parser(
+        "fair-value-bands",
+        help=(
+            "Compute and screen Fair Value Bands (33 SMA of OHLC4 + "
+            "median-deviation threshold bands)"
+        ),
+    )
+    fair_value_bands_subparsers = fair_value_bands_parser.add_subparsers(
+        dest="fair_value_bands_command", metavar="COMMAND"
+    )
+    fair_value_bands_subparsers.required = True
+
+    fair_value_bands_compute_parser = fair_value_bands_subparsers.add_parser(
+        "compute",
+        help="Compute and persist fair value bands for the selected timeframe",
+    )
+    fair_value_bands_compute_parser.add_argument(
+        "--timeframe",
+        choices=["daily", "weekly", "monthly"],
+        default="monthly",
+        help=(
+            "Display timeframe; daily overlays weekly and weekly overlays "
+            "monthly bands (default: monthly)"
+        ),
+    )
+    fair_value_bands_compute_parser.add_argument(
+        "--output-dir", type=Path, metavar="DIR"
+    )
+
+    fair_value_bands_screen_parser = fair_value_bands_subparsers.add_parser(
+        "screen", help="Screen persisted fair value bands for the selected timeframe"
+    )
+    fair_value_bands_screen_parser.add_argument(
+        "--timeframe",
+        choices=["daily", "weekly", "monthly"],
+        default="monthly",
+        help=(
+            "Display timeframe; daily overlays weekly and weekly overlays "
+            "monthly bands (default: monthly)"
+        ),
+    )
+    fair_value_bands_screen_parser.add_argument(
+        "--zone",
+        choices=["below_lower", "above_upper", "in_band", "all"],
+        default="all",
+        help="Zone to filter on (default: all actionable zones)",
+    )
+    fair_value_bands_screen_parser.add_argument(
+        "--min-close",
+        type=float,
+        default=5.0,
+        metavar="DOLLARS",
+        help="Minimum current close price to include (default: 5.0; use 0 to disable)",
+    )
+    fair_value_bands_screen_parser.add_argument(
+        "--limit",
+        type=_parse_positive_int,
+        default=None,
+        help="Cap the number of rows displayed",
+    )
+    fair_value_bands_screen_parser.add_argument(
+        "--output-dir", type=Path, metavar="DIR"
+    )
+
     return parser
 
 
@@ -156,6 +220,28 @@ def _dispatch_fib_zones(
             parser.error(str(err))
 
 
+def _dispatch_fair_value_bands(
+    parser: argparse.ArgumentParser, args: argparse.Namespace, config: Config
+) -> None:
+    """Dispatch fair-value-bands compute/screen subcommands, wrapping ValueErrors."""
+    if args.fair_value_bands_command == "compute":
+        try:
+            pipeline.compute_fair_value_bands(config, args.timeframe)
+        except ValueError as err:
+            parser.error(str(err))
+    elif args.fair_value_bands_command == "screen":
+        try:
+            pipeline.screen_fair_value_bands(
+                config,
+                args.timeframe,
+                zone=args.zone,
+                limit=args.limit,
+                min_close=args.min_close,
+            )
+        except ValueError as err:
+            parser.error(str(err))
+
+
 def main() -> None:
     """Parse CLI arguments and dispatch to appropriate pipeline function."""
     parser = _build_parser()
@@ -168,14 +254,11 @@ def main() -> None:
     )
     config = _make_config(args)
 
-    if args.command == "backfill":
+    if args.command in {"backfill", "update"}:
         try:
-            pipeline.backfill(config)
-        except ValueError as err:
-            parser.error(str(err))
-    elif args.command == "update":
-        try:
-            pipeline.update(config)
+            {"backfill": pipeline.backfill, "update": pipeline.update}[args.command](
+                config
+            )
         except ValueError as err:
             parser.error(str(err))
     elif args.command == "info":
@@ -189,3 +272,5 @@ def main() -> None:
             parser.error(str(err))
     elif args.command == "fib-zones":
         _dispatch_fib_zones(parser, args, config)
+    elif args.command == "fair-value-bands":
+        _dispatch_fair_value_bands(parser, args, config)

--- a/src/tickerlake/fair_value_bands.py
+++ b/src/tickerlake/fair_value_bands.py
@@ -1,0 +1,278 @@
+"""Native Fair Value Bands and higher-timeframe overlay alignment.
+
+The indicator uses a 33-period SMA of OHLC4 and expanding median deviations.
+Native calculation always operates on the bars supplied by the caller.
+Higher-timeframe overlays are aligned separately with a backward as-of join.
+
+For each ticker, a bar contributes upper and lower deviations when its high
+and low straddle the fair value.
+The expanding medians of those deviations define the bands available on that
+bar, so a later observation never changes an earlier result.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+
+from tickerlake.transform import VALID_TIMEFRAMES
+
+# Public schema shared by all fair-value-band timeframe tables.
+FAIR_VALUE_BANDS_SCHEMA: dict = {
+    "ticker": pl.Utf8,
+    "as_of_date": pl.Date,
+    "fair_value": pl.Float32,
+    "upper_band": pl.Float32,
+    "lower_band": pl.Float32,
+    "current_close": pl.Float32,
+    "upper_dev": pl.Float32,
+    "lower_dev": pl.Float32,
+    "n_straddling_bars": pl.UInt32,
+    "zone": pl.Utf8,
+    "bar_count": pl.UInt32,
+}
+
+# Indicator parameter: the tested setting from the original indicator.
+SMA_PERIOD: int = 33
+
+# Zone labels.
+ZONE_BELOW_LOWER = "below_lower"
+ZONE_IN_BAND = "in_band"
+ZONE_ABOVE_UPPER = "above_upper"
+
+
+def _validate_timeframe(timeframe: str) -> None:
+    if timeframe not in VALID_TIMEFRAMES:
+        msg = f"timeframe must be one of: {', '.join(sorted(VALID_TIMEFRAMES))}"
+        raise ValueError(msg)
+
+
+def _empty_df() -> pl.DataFrame:
+    return pl.DataFrame(schema=FAIR_VALUE_BANDS_SCHEMA)
+
+
+def _compute_ohlc4(bars: pl.DataFrame) -> pl.DataFrame:
+    """Add OHLC4 = (open + high + low + close) / 4 to timeframe bars."""
+    sum_ohlc = pl.col("open") + pl.col("high") + pl.col("low") + pl.col("close")
+    return bars.with_columns(
+        (sum_ohlc.cast(pl.Float64) / pl.lit(4.0)).cast(pl.Float32).alias("ohlc4")
+    )
+
+
+def _compute_fair_value(bars: pl.DataFrame, period: int = SMA_PERIOD) -> pl.DataFrame:
+    """Compute the period-SMA of OHLC4 per ticker."""
+    sorted_bars = bars.sort(["ticker", "date"])
+    return sorted_bars.with_columns(
+        pl.col("ohlc4")
+        .cast(pl.Float64)
+        .rolling_mean(period)
+        .over("ticker")
+        .cast(pl.Float32)
+        .alias("fair_value")
+    )
+
+
+def _per_ticker_band_widths(bars_with_fv: pl.DataFrame) -> pl.DataFrame:
+    """Compute expanding median deviations and cumulative straddling counts."""
+    if bars_with_fv.is_empty():
+        return pl.DataFrame(
+            schema={
+                "ticker": pl.Utf8,
+                "date": pl.Date,
+                "upper_dev": pl.Float32,
+                "lower_dev": pl.Float32,
+                "n_straddling_bars": pl.UInt32,
+            }
+        )
+
+    bars = bars_with_fv.sort(["ticker", "date"])
+    fv64 = pl.col("fair_value").cast(pl.Float64)
+    high64 = pl.col("high").cast(pl.Float64)
+    low64 = pl.col("low").cast(pl.Float64)
+    straddles = (
+        pl.col("fair_value").is_not_null()
+        & (pl.col("fair_value") > 0)
+        & (pl.col("low") < pl.col("fair_value"))
+        & (pl.col("high") > pl.col("fair_value"))
+    )
+    deviations = bars.with_columns(
+        [
+            pl.when(straddles)
+            .then((high64 - fv64) / fv64)
+            .otherwise(None)
+            .cast(pl.Float32)
+            .alias("upper_dev"),
+            pl.when(straddles)
+            .then((fv64 - low64) / fv64)
+            .otherwise(None)
+            .cast(pl.Float32)
+            .alias("lower_dev"),
+        ]
+    )
+    # A full-input rolling window becomes an expanding window within each
+    # ticker, while null deviations are ignored by rolling_median.
+    window_size = deviations.height
+    return deviations.with_columns(
+        [
+            pl.col("upper_dev")
+            .rolling_median(window_size=window_size, min_samples=1)
+            .over("ticker")
+            .cast(pl.Float32)
+            .alias("upper_dev"),
+            pl.col("lower_dev")
+            .rolling_median(window_size=window_size, min_samples=1)
+            .over("ticker")
+            .cast(pl.Float32)
+            .alias("lower_dev"),
+            pl.col("upper_dev")
+            .is_not_null()
+            .cast(pl.UInt32)
+            .cum_sum()
+            .over("ticker")
+            .alias("n_straddling_bars"),
+        ]
+    ).select(
+        [
+            "ticker",
+            "date",
+            "upper_dev",
+            "lower_dev",
+            "n_straddling_bars",
+        ]
+    )
+
+
+def _zone_expression() -> pl.Expr:
+    """Classify closes relative to the exclusive band boundaries."""
+    return (
+        pl.when(pl.col("current_close") < pl.col("lower_band"))
+        .then(pl.lit(ZONE_BELOW_LOWER))
+        .when(pl.col("current_close") > pl.col("upper_band"))
+        .then(pl.lit(ZONE_ABOVE_UPPER))
+        .otherwise(pl.lit(ZONE_IN_BAND))
+    )
+
+
+def compute_native_fair_value_bands(bars: pl.DataFrame) -> pl.DataFrame:
+    """Compute native Fair Value Bands for already-aggregated bars."""
+    if bars is None or bars.is_empty():
+        return _empty_df()
+
+    with_ohlc4 = _compute_ohlc4(bars)
+    with_fv = _compute_fair_value(with_ohlc4)
+    deviations = _per_ticker_band_widths(with_fv)
+    joined = (
+        with_fv.with_columns(
+            pl.int_range(1, pl.len() + 1)
+            .over("ticker")
+            .cast(pl.UInt32)
+            .alias("bar_count")
+        )
+        .join(deviations, on=["ticker", "date"], how="inner")
+        .filter(pl.col("upper_dev").is_not_null())
+        .with_columns(
+            [
+                pl.col("date").alias("as_of_date"),
+                pl.col("close").cast(pl.Float32).alias("current_close"),
+            ]
+        )
+    )
+    if joined.is_empty():
+        return _empty_df()
+
+    fv64 = pl.col("fair_value").cast(pl.Float64)
+    upper_expr = (fv64 * (pl.lit(1.0) + pl.col("upper_dev").cast(pl.Float64))).cast(
+        pl.Float32
+    )
+    lower_expr = (fv64 * (pl.lit(1.0) - pl.col("lower_dev").cast(pl.Float64))).cast(
+        pl.Float32
+    )
+    return (
+        joined.with_columns(
+            [upper_expr.alias("upper_band"), lower_expr.alias("lower_band")]
+        )
+        .with_columns(_zone_expression().alias("zone"))
+        .select(list(FAIR_VALUE_BANDS_SCHEMA))
+        .sort(["ticker", "as_of_date"])
+    )
+
+
+def compute_fair_value_bands(
+    bars: pl.DataFrame, timeframe: str = "monthly"
+) -> pl.DataFrame:
+    """Compute native Fair Value Bands for a valid source timeframe."""
+    _validate_timeframe(timeframe)
+    return compute_native_fair_value_bands(bars)
+
+
+def _validate_source_timeframe(source_timeframe: str) -> None:
+    if source_timeframe not in {"weekly", "monthly"}:
+        msg = "source_timeframe must be one of: monthly, weekly"
+        raise ValueError(msg)
+
+
+def _source_availability_expression(source_timeframe: str) -> pl.Expr:
+    if source_timeframe == "weekly":
+        return pl.col("source_date") + pl.duration(weeks=1)
+    return pl.col("source_date").dt.month_start().dt.offset_by("1mo")
+
+
+def align_fair_value_bands(
+    source_bands: pl.DataFrame,
+    display_bars: pl.DataFrame,
+    source_timeframe: str,
+) -> pl.DataFrame:
+    """Overlay confirmed source bands on display bars without looking ahead.
+
+    Weekly source bands become available on the following Monday.
+    Monthly source bands become available on the first day of the following
+    calendar month.
+    """
+    _validate_source_timeframe(source_timeframe)
+    if source_bands is None or source_bands.is_empty():
+        return _empty_df()
+    if display_bars is None or display_bars.is_empty():
+        return _empty_df()
+
+    source = (
+        source_bands.select(
+            [
+                "ticker",
+                "as_of_date",
+                "fair_value",
+                "upper_band",
+                "lower_band",
+                "upper_dev",
+                "lower_dev",
+                "n_straddling_bars",
+                "bar_count",
+            ]
+        )
+        .rename({"as_of_date": "source_date"})
+        .with_columns(
+            _source_availability_expression(source_timeframe).alias("available_date")
+        )
+        .sort(["ticker", "available_date"])
+    )
+    display = display_bars.select(["ticker", "date", "close"]).sort(["ticker", "date"])
+    joined = display.join_asof(
+        source,
+        left_on="date",
+        right_on="available_date",
+        by="ticker",
+        strategy="backward",
+        check_sortedness=False,
+    ).filter(pl.col("fair_value").is_not_null())
+    if joined.is_empty():
+        return _empty_df()
+
+    return (
+        joined.with_columns(
+            [
+                pl.col("date").alias("as_of_date"),
+                pl.col("close").cast(pl.Float32).alias("current_close"),
+            ]
+        )
+        .with_columns(_zone_expression().alias("zone"))
+        .select(list(FAIR_VALUE_BANDS_SCHEMA))
+        .sort(["ticker", "as_of_date"])
+    )

--- a/src/tickerlake/load.py
+++ b/src/tickerlake/load.py
@@ -9,6 +9,8 @@ import duckdb
 import polars as pl
 
 from tickerlake.extract import DAILY_AGGS_SCHEMA, TICKERS_SCHEMA
+from tickerlake.fair_value_bands import FAIR_VALUE_BANDS_SCHEMA
+from tickerlake.transform import VALID_TIMEFRAMES
 
 if TYPE_CHECKING:
     import datetime
@@ -27,9 +29,7 @@ _METRICS_SCHEMA = {
 }
 
 
-def _validate_schema(
-    table: str, df: pl.DataFrame, expected: dict[str, pl.DataType]
-) -> None:
+def _validate_schema(table: str, df: pl.DataFrame, expected: dict) -> None:
     """Validate a DataFrame schema before writing a DuckDB table."""
     mismatches = _schema_mismatches(dict(df.schema), expected)
 
@@ -38,9 +38,7 @@ def _validate_schema(
         raise ValueError(msg)
 
 
-def _schema_mismatches(
-    actual: dict[str, pl.DataType], expected: dict[str, pl.DataType]
-) -> list[str]:
+def _schema_mismatches(actual: dict, expected: dict) -> list[str]:
     missing = [col for col in expected if col not in actual]
     extra = [col for col in actual if col not in expected]
     wrong_dtype = [
@@ -335,6 +333,71 @@ def read_weekly_fib_zones(
             con.execute(sql, params)
         except duckdb.CatalogException as err:
             msg = f"weekly_fib_zones table not found in consumer DB: {path}"
+            raise ValueError(msg) from err
+        finally:
+            con.close()
+        return pl.read_parquet(tmp)
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def _fair_value_bands_table(timeframe: str) -> str:
+    """Return the persisted Fair Value Bands table for a valid timeframe."""
+    if timeframe not in VALID_TIMEFRAMES:
+        msg = f"timeframe must be one of: {', '.join(sorted(VALID_TIMEFRAMES))}"
+        raise ValueError(msg)
+    return f"{timeframe}_fair_value_bands"
+
+
+def write_fair_value_bands(
+    df: pl.DataFrame, path: Path, timeframe: str = "monthly"
+) -> None:
+    """Write Fair Value Bands to the selected timeframe table."""
+    table = _fair_value_bands_table(timeframe)
+    _validate_schema(table, df, FAIR_VALUE_BANDS_SCHEMA)
+    with _tmp_parquet(df) as tmp:
+        con = duckdb.connect(str(path))
+        try:
+            con.execute(
+                f"CREATE OR REPLACE TABLE {table} AS "
+                f"{_read_parquet_sql(tmp, 'ticker, as_of_date')}"
+            )
+            con.execute("CHECKPOINT")
+        finally:
+            con.close()
+
+
+def read_fair_value_bands(
+    path: Path,
+    timeframe: str = "monthly",
+    *,
+    zone: str | list[str] | None = None,
+) -> pl.DataFrame:
+    """Read Fair Value Bands for a timeframe, optionally filtering by zone.
+
+    Returns rows sorted by ticker and observation date.
+    """
+    table = _fair_value_bands_table(timeframe)
+    if not path.exists():
+        msg = f"Consumer DB not found: {path}"
+        raise ValueError(msg)
+
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        tmp = Path(f.name)
+    try:
+        con = duckdb.connect(str(path), read_only=True)
+        try:
+            sql = f"COPY (SELECT * FROM {table}"
+            params: list[str] = []
+            if zone is not None:
+                zones = [zone] if isinstance(zone, str) else list(zone)
+                placeholders = ", ".join(["?"] * len(zones))
+                sql += f" WHERE zone IN ({placeholders})"
+                params = zones
+            sql += f" ORDER BY ticker, as_of_date) TO '{tmp}' (FORMAT PARQUET)"
+            con.execute(sql, params)
+        except duckdb.CatalogException as err:
+            msg = f"{table} table not found in consumer DB: {path}"
             raise ValueError(msg) from err
         finally:
             con.close()

--- a/src/tickerlake/pipeline.py
+++ b/src/tickerlake/pipeline.py
@@ -15,6 +15,15 @@ from tickerlake import console
 from tickerlake.calendar import get_trading_days
 from tickerlake.client import MassiveClient
 from tickerlake.extract import extract_daily_aggs, extract_splits, extract_tickers
+from tickerlake.fair_value_bands import (
+    FAIR_VALUE_BANDS_SCHEMA,
+)
+from tickerlake.fair_value_bands import (
+    align_fair_value_bands as _align_fair_value_bands,
+)
+from tickerlake.fair_value_bands import (
+    compute_native_fair_value_bands as _compute_native_fair_value_bands,
+)
 from tickerlake.fib_zones import WEEKLY_FIB_ZONES_SCHEMA, compute_weekly_fib_zones_all
 from tickerlake.load import (
     append_raw_db,
@@ -23,9 +32,11 @@ from tickerlake.load import (
     get_db_info,
     get_existing_dates,
     read_adjusted_daily_bars_for_ticker,
+    read_fair_value_bands,
     read_raw_db,
     read_weekly_fib_zones,
     write_consumer_db,
+    write_fair_value_bands,
     write_raw_db,
     write_splits,
     write_weekly_fib_zones,
@@ -60,6 +71,9 @@ _LIQUIDITY_VOLUME_THRESHOLD = 1_000_000.0
 # degree is void are additionally excluded because their swing-low setup has
 # already broken.
 _ACTIONABLE_ZONES = ["in_ibz", "in_smz", "below_smz"]
+# Actionable Fair Value Band zones: below the lower band (discount) or above
+# the upper band (premium). Rows in the neutral in_band zone are excluded.
+_ACTIONABLE_FVB_ZONES = ["below_lower", "above_upper"]
 
 
 def _verify_split_adjustment(
@@ -518,4 +532,194 @@ def screen_fib_zones(
         zone,
         limit_label,
         min_swing_low,
+    )
+
+
+def _fair_value_bands_table(timeframe: str) -> str:
+    """Return the Fair Value Bands table for a valid timeframe."""
+    if timeframe not in VALID_TIMEFRAMES:
+        msg = f"timeframe must be one of: {', '.join(sorted(VALID_TIMEFRAMES))}"
+        raise ValueError(msg)
+    return f"{timeframe}_fair_value_bands"
+
+
+def _fair_value_bands_source_timeframe(display_timeframe: str) -> str:
+    """Return the native band timeframe used for a display timeframe."""
+    if display_timeframe == "daily":
+        return "weekly"
+    return "monthly"
+
+
+def _read_fair_value_bands_bars(consumer_path: Path, timeframe: str) -> pl.DataFrame:
+    """Read the persisted bars table matching ``timeframe`` via parquet."""
+    _fair_value_bands_table(timeframe)
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as bars_file:
+        bars_tmp = Path(bars_file.name)
+    try:
+        con = duckdb.connect(str(consumer_path), read_only=True)
+        try:
+            con.execute(
+                f"COPY (SELECT * FROM {timeframe}_bars ORDER BY ticker, date) "
+                f"TO '{bars_tmp}' (FORMAT PARQUET)"
+            )
+        except duckdb.CatalogException as err:
+            msg = (
+                f"{timeframe}_bars table not found in consumer DB: "
+                f"{consumer_path}. Run backfill first."
+            )
+            raise ValueError(msg) from err
+        finally:
+            con.close()
+        return pl.read_parquet(bars_tmp)
+    finally:
+        bars_tmp.unlink(missing_ok=True)
+
+
+def _validate_fair_value_bands_schema(df: pl.DataFrame, timeframe: str) -> None:
+    """Raise ValueError when a result does not match the shared schema."""
+    table = _fair_value_bands_table(timeframe)
+    actual = dict(df.schema)
+    mismatches = [
+        f"{col}: expected {dtype}, got {actual[col]}"
+        for col, dtype in FAIR_VALUE_BANDS_SCHEMA.items()
+        if col in actual and actual[col] != dtype
+    ]
+    missing = sorted(set(FAIR_VALUE_BANDS_SCHEMA) - set(actual))
+    extra = sorted(set(actual) - set(FAIR_VALUE_BANDS_SCHEMA))
+    problems = [
+        *([f"missing columns: {', '.join(missing)}"] if missing else []),
+        *([f"unexpected columns: {', '.join(extra)}"] if extra else []),
+        *mismatches,
+    ]
+    if problems:
+        msg = f"{table} schema mismatch: " + "; ".join(problems)
+        raise ValueError(msg)
+
+
+def compute_fair_value_bands(config: Config, timeframe: str = "monthly") -> None:
+    """Compute and persist Fair Value Bands for the selected timeframe.
+
+    Monthly uses native monthly bands, weekly overlays native monthly bands on
+    weekly bars, and daily overlays native weekly bands on daily bars.
+    """
+    table = _fair_value_bands_table(timeframe)
+    consumer_path = config.output_dir / "tickerlake.duckdb"
+    if not consumer_path.exists():
+        msg = f"Consumer DB not found: {consumer_path}. Run backfill first."
+        raise ValueError(msg)
+
+    display_bars = _read_fair_value_bands_bars(consumer_path, timeframe)
+    source_timeframe = _fair_value_bands_source_timeframe(timeframe)
+    source_bars = (
+        display_bars
+        if source_timeframe == timeframe
+        else _read_fair_value_bands_bars(consumer_path, source_timeframe)
+    )
+    logger.info(
+        "Computing %s fair value bands for %d source bars displayed on %d %s bars.",
+        source_timeframe,
+        len(source_bars),
+        len(display_bars),
+        timeframe,
+    )
+
+    native_bands = _compute_native_fair_value_bands(source_bars)
+    bands = (
+        native_bands
+        if source_timeframe == timeframe
+        else _align_fair_value_bands(native_bands, display_bars, source_timeframe)
+    )
+    _validate_fair_value_bands_schema(bands, timeframe)
+
+    n_below_lower = int(bands.filter(pl.col("zone") == "below_lower").height)
+    n_above_upper = int(bands.filter(pl.col("zone") == "above_upper").height)
+    n_in_band = int(bands.filter(pl.col("zone") == "in_band").height)
+    write_fair_value_bands(bands, consumer_path, timeframe)
+
+    n_total_tickers = (
+        display_bars["ticker"].n_unique() if not display_bars.is_empty() else 0
+    )
+    n_written_tickers = bands["ticker"].n_unique() if not bands.is_empty() else 0
+    n_excluded = n_total_tickers - n_written_tickers
+    logger.info(
+        "%s fair value bands written: n_below_lower=%d, n_above_upper=%d, "
+        "n_in_band=%d, n_written=%d, n_excluded=%d (warmup/no-straddles/zero-fv).",
+        timeframe.capitalize(),
+        n_below_lower,
+        n_above_upper,
+        n_in_band,
+        len(bands),
+        n_excluded,
+    )
+    logger.debug("Fair Value Bands output table: %s", table)
+
+
+def screen_fair_value_bands(
+    config: Config,
+    timeframe: str = "monthly",
+    *,
+    zone: str = "all",
+    limit: int | None = None,
+    min_close: float = 5.0,
+) -> None:
+    """Print persisted Fair Value Bands for the selected timeframe.
+
+    ``zone="all"`` restricts results to the actionable below-lower and
+    above-upper zones.
+    """
+    _fair_value_bands_table(timeframe)
+    consumer_path = config.output_dir / "tickerlake.duckdb"
+    if not consumer_path.exists():
+        msg = (
+            f"Consumer DB not found: {consumer_path}. "
+            "Run fair-value-bands compute first."
+        )
+        raise ValueError(msg)
+
+    if zone == "all":
+        result = read_fair_value_bands(
+            consumer_path, timeframe, zone=_ACTIONABLE_FVB_ZONES
+        )
+    else:
+        result = read_fair_value_bands(consumer_path, timeframe, zone=zone)
+    result = result.filter(pl.col("current_close") >= min_close)
+    result = result.sort(["ticker", "as_of_date"])
+
+    total = result.height
+    displayed = result.head(limit) if limit is not None else result
+
+    title = f"{timeframe.capitalize()} fair value bands screen"
+    table = Table(title=title, header_style="bold")
+    table.add_column("ticker", style="bold")
+    table.add_column("as_of_date", no_wrap=True)
+    table.add_column("current_close", justify="right")
+    table.add_column("fair_value", justify="right")
+    table.add_column("upper_band", justify="right")
+    table.add_column("lower_band", justify="right")
+    table.add_column("zone")
+    table.add_column("n_straddling_bars", justify="right")
+
+    for row in displayed.iter_rows(named=True):
+        table.add_row(
+            row["ticker"],
+            row["as_of_date"].isoformat(),
+            f"{row['current_close']:.2f}",
+            f"{row['fair_value']:.2f}",
+            f"{row['upper_band']:.2f}",
+            f"{row['lower_band']:.2f}",
+            row["zone"],
+            str(row["n_straddling_bars"]),
+        )
+    console.print(table)
+
+    limit_label = str(limit) if limit is not None else "unlimited"
+    logger.info(
+        "Screen: %d total matches, %d displayed (timeframe=%s, zone=%s, "
+        "limit=%s, min_close=%s).",
+        total,
+        displayed.height,
+        timeframe,
+        zone,
+        limit_label,
+        min_close,
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -506,3 +506,178 @@ class TestFibZonesSubcommand:
         assert exc_info.value.code != 0
         assert "missing db" in captured.err
         assert "Traceback" not in captured.err
+
+
+class TestFairValueBandsSubcommand:
+    """Test Fair Value Bands timeframe forwarding and screen options."""
+
+    def test_fair_value_bands_compute_calls_pipeline(self, monkeypatch, tmp_path):
+        """Verify compute forwards the selected timeframe."""
+        monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
+        with patch("tickerlake.pipeline.compute_fair_value_bands") as mock_compute:
+            monkeypatch.setattr(
+                "sys.argv",
+                [
+                    "tickerlake",
+                    "fair-value-bands",
+                    "compute",
+                    "--timeframe",
+                    "daily",
+                    "--output-dir",
+                    str(tmp_path),
+                ],
+            )
+            main()
+            mock_compute.assert_called_once()
+            config = mock_compute.call_args[0][0]
+            assert isinstance(config, Config)
+            assert config.output_dir == tmp_path
+            assert mock_compute.call_args[0][1] == "daily"
+
+    def test_fair_value_bands_compute_defaults_to_monthly(self, monkeypatch):
+        """Verify compute defaults to the monthly timeframe."""
+        monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
+        with patch("tickerlake.pipeline.compute_fair_value_bands") as mock_compute:
+            monkeypatch.setattr(
+                "sys.argv", ["tickerlake", "fair-value-bands", "compute"]
+            )
+            main()
+            assert mock_compute.call_args[0][1] == "monthly"
+
+    def test_fair_value_bands_screen_calls_pipeline(self, monkeypatch, tmp_path):
+        """Verify screen forwards timeframe, zone, min-close, and output-dir."""
+        monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
+        with patch("tickerlake.pipeline.screen_fair_value_bands") as mock_screen:
+            monkeypatch.setattr(
+                "sys.argv",
+                [
+                    "tickerlake",
+                    "fair-value-bands",
+                    "screen",
+                    "--timeframe",
+                    "weekly",
+                    "--zone",
+                    "below_lower",
+                    "--min-close",
+                    "10",
+                    "--output-dir",
+                    str(tmp_path),
+                ],
+            )
+            main()
+            mock_screen.assert_called_once()
+            config = mock_screen.call_args[0][0]
+            assert isinstance(config, Config)
+            assert config.output_dir == tmp_path
+            assert mock_screen.call_args[0][1] == "weekly"
+            assert mock_screen.call_args.kwargs["zone"] == "below_lower"
+            assert mock_screen.call_args.kwargs["min_close"] == 10.0
+
+    def test_fair_value_bands_screen_defaults(self, monkeypatch, tmp_path):
+        """Verify fair-value-bands screen defaults to zone=all, min_close=5.0."""
+        monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
+        with patch("tickerlake.pipeline.screen_fair_value_bands") as mock_screen:
+            monkeypatch.setattr(
+                "sys.argv",
+                [
+                    "tickerlake",
+                    "fair-value-bands",
+                    "screen",
+                    "--output-dir",
+                    str(tmp_path),
+                ],
+            )
+            main()
+            assert mock_screen.call_args[0][1] == "monthly"
+            assert mock_screen.call_args.kwargs["zone"] == "all"
+            assert mock_screen.call_args.kwargs["limit"] is None
+            assert mock_screen.call_args.kwargs["min_close"] == 5.0
+
+    def test_fair_value_bands_screen_limit(self, monkeypatch, tmp_path):
+        """Verify fair-value-bands screen --limit caps the number of rows displayed."""
+        monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
+        with patch("tickerlake.pipeline.screen_fair_value_bands") as mock_screen:
+            monkeypatch.setattr(
+                "sys.argv",
+                [
+                    "tickerlake",
+                    "fair-value-bands",
+                    "screen",
+                    "--limit",
+                    "5",
+                    "--output-dir",
+                    str(tmp_path),
+                ],
+            )
+            main()
+            assert mock_screen.call_args.kwargs["limit"] == 5
+
+    def test_fair_value_bands_screen_invalid_zone(self, monkeypatch):
+        """Verify an unknown --zone value exits with an argparse error."""
+        monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["tickerlake", "fair-value-bands", "screen", "--zone", "bogus"],
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code != 0
+
+    def test_fair_value_bands_screen_invalid_limit(self, monkeypatch):
+        """Verify --limit must be a positive integer."""
+        monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
+        monkeypatch.setattr(
+            "sys.argv",
+            ["tickerlake", "fair-value-bands", "screen", "--limit", "0"],
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code != 0
+
+    def test_fair_value_bands_no_subcommand(self, monkeypatch):
+        """Verify fair-value-bands without a subcommand exits with an error."""
+        monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
+        monkeypatch.setattr("sys.argv", ["tickerlake", "fair-value-bands"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code != 0
+
+    def test_fair_value_bands_compute_value_error_becomes_cli_error(
+        self, monkeypatch, capsys
+    ):
+        """Verify a compute ValueError exits cleanly without a traceback."""
+        monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
+        with patch(
+            "tickerlake.pipeline.compute_fair_value_bands",
+            side_effect=ValueError("missing db"),
+        ):
+            monkeypatch.setattr(
+                "sys.argv", ["tickerlake", "fair-value-bands", "compute"]
+            )
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code != 0
+        assert "missing db" in captured.err
+        assert "Traceback" not in captured.err
+
+    def test_fair_value_bands_screen_value_error_becomes_cli_error(
+        self, monkeypatch, capsys
+    ):
+        """Verify a screen ValueError exits cleanly without a traceback."""
+        monkeypatch.setenv("MASSIVE_API_KEY", "test_key")
+        with patch(
+            "tickerlake.pipeline.screen_fair_value_bands",
+            side_effect=ValueError("missing db"),
+        ):
+            monkeypatch.setattr(
+                "sys.argv", ["tickerlake", "fair-value-bands", "screen"]
+            )
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        captured = capsys.readouterr()
+        assert exc_info.value.code != 0
+        assert "missing db" in captured.err
+        assert "Traceback" not in captured.err

--- a/tests/test_fair_value_bands.py
+++ b/tests/test_fair_value_bands.py
@@ -1,0 +1,709 @@
+"""Tests for tickerlake.fair_value_bands across all supported timeframes."""
+
+import datetime
+
+import polars as pl
+import pytest
+
+from tickerlake.fair_value_bands import (
+    FAIR_VALUE_BANDS_SCHEMA,
+    SMA_PERIOD,
+    ZONE_ABOVE_UPPER,
+    ZONE_BELOW_LOWER,
+    ZONE_IN_BAND,
+    _compute_fair_value,
+    _compute_ohlc4,
+    _per_ticker_band_widths,
+    _zone_expression,
+    align_fair_value_bands,
+    compute_fair_value_bands,
+)
+
+
+def _make_bars(
+    rows: list[dict],
+    *,
+    sort: bool = True,
+) -> pl.DataFrame:
+    """Build a polars DataFrame of monthly bars from a list of row dicts.
+
+    Each row dict must have: date (datetime.date), ticker (str), open, high,
+    low, close (numbers). Volume is filled with 1M. Casts dtypes to match
+    the project convention (Float32 / Date / Utf8).
+    """
+    if not rows:
+        return pl.DataFrame(schema=FAIR_VALUE_BANDS_SCHEMA)
+    df = pl.DataFrame(
+        {
+            "date": [r["date"] for r in rows],
+            "ticker": [r["ticker"] for r in rows],
+            "open": [r["open"] for r in rows],
+            "high": [r["high"] for r in rows],
+            "low": [r["low"] for r in rows],
+            "close": [r["close"] for r in rows],
+            "volume": [1_000_000.0] * len(rows),
+        }
+    ).with_columns(
+        pl.col("date").cast(pl.Date),
+        pl.col("ticker").cast(pl.Utf8),
+        pl.col("open").cast(pl.Float32),
+        pl.col("high").cast(pl.Float32),
+        pl.col("low").cast(pl.Float32),
+        pl.col("close").cast(pl.Float32),
+        pl.col("volume").cast(pl.Float32),
+    )
+    return df.sort(["ticker", "date"]) if sort else df
+
+
+def _dates(start: datetime.date, n: int) -> list[datetime.date]:
+    """Generate n ordered observation dates starting at `start`."""
+    out: list[datetime.date] = []
+    for i in range(n):
+        month_index = start.month + i - 1
+        year = start.year + month_index // 12
+        month = month_index % 12 + 1
+        out.append(datetime.date(year, month, 1))
+    return out
+
+
+def test_constants_locked() -> None:
+    """SMA_PERIOD must match the THT Fair Value Bands default."""
+    assert SMA_PERIOD == 33
+
+
+def test_empty_input_returns_empty_schema() -> None:
+    """Empty and None inputs return an empty DataFrame matching the schema."""
+    empty = compute_fair_value_bands(pl.DataFrame())
+    assert empty.is_empty()
+    assert dict(empty.schema) == dict(FAIR_VALUE_BANDS_SCHEMA)
+    assert compute_fair_value_bands(None) is not None  # type: ignore[arg-type]
+    assert compute_fair_value_bands(None).is_empty()  # type: ignore[arg-type]
+
+
+def test_compute_ohlc4_basic() -> None:
+    """OHLC4 = (open + high + low + close) / 4."""
+    bars = _make_bars(
+        [
+            {
+                "date": datetime.date(2024, 1, 31),
+                "ticker": "A",
+                "open": 100.0,
+                "high": 110.0,
+                "low": 90.0,
+                "close": 100.0,
+            }
+        ]
+    )
+    out = _compute_ohlc4(bars)
+    assert out["ohlc4"][0] == pytest.approx(100.0, abs=1e-5)
+    assert out.schema["ohlc4"] == pl.Float32
+
+
+def test_compute_fair_value_sma33_warmup() -> None:
+    """First 32 OHLC4 values per ticker are null; 33rd is the first non-null."""
+    dates = _dates(datetime.date(2020, 1, 1), 40)
+    rows = [
+        {
+            "date": dates[i],
+            "ticker": "A",
+            "open": 100.0,
+            "high": 102.0,
+            "low": 98.0,
+            "close": 100.0,
+        }
+        for i in range(40)
+    ]
+    bars = _compute_ohlc4(_make_bars(rows))
+    fv = _compute_fair_value(bars)
+    fv_list = fv["fair_value"].to_list()
+    # First 32 rows are null.
+    assert all(v is None for v in fv_list[:32])
+    # 33rd row is non-null and equals the OHLC4 mean (100.0).
+    assert fv_list[32] == pytest.approx(100.0, abs=1e-4)
+    # All subsequent rows are non-null.
+    assert all(v is not None for v in fv_list[33:])
+
+
+def test_per_ticker_band_widths_drops_no_straddles() -> None:
+    """Widths stay undefined for tickers whose bars never straddle fv."""
+    dates = _dates(datetime.date(2020, 1, 1), 40)
+    # Ticker A: constant bars at 110 — OHLC4=110, fv=110, low=high=110, never straddles.
+    # Ticker B: bars straddle fv=100 — open=close=100, low=95, high=105.
+    rows_a = [
+        {
+            "date": dates[i],
+            "ticker": "A",
+            "open": 110.0,
+            "high": 110.0,
+            "low": 110.0,
+            "close": 110.0,
+        }
+        for i in range(40)
+    ]
+    rows_b = [
+        {
+            "date": dates[i],
+            "ticker": "B",
+            "open": 100.0,
+            "high": 105.0,
+            "low": 95.0,
+            "close": 100.0,
+        }
+        for i in range(40)
+    ]
+    bars = _compute_fair_value(_compute_ohlc4(_make_bars(rows_a + rows_b)))
+    widths = _per_ticker_band_widths(bars)
+    assert widths["ticker"].n_unique() == 2
+    assert widths.filter(pl.col("ticker") == "A")["upper_dev"].null_count() == 40
+    b_widths = widths.filter(pl.col("ticker") == "B")
+    assert b_widths["n_straddling_bars"].to_list()[:32] == [0] * 32
+    assert b_widths["n_straddling_bars"].to_list()[-1] == 8
+    assert b_widths["upper_dev"].tail(1)[0] == pytest.approx(0.05, abs=1e-4)
+    assert b_widths["lower_dev"].tail(1)[0] == pytest.approx(0.05, abs=1e-4)
+
+
+def test_per_ticker_band_widths_median_known_value() -> None:
+    """Median of a known set of deviations matches polars' median.
+
+    Build 33 post-warmup bars with d=1,2,...,33 → upper_dev = d/100.
+    Median of 33 values (1..33)/100 = 17/100 = 0.17.
+    """
+    dates = _dates(datetime.date(2020, 1, 1), 65)
+    zero_row = {
+        "ticker": "A",
+        "open": 100.0,
+        "high": 100.0,
+        "low": 100.0,
+        "close": 100.0,
+    }
+    rows = [{**zero_row, "date": dates[i]} for i in range(32)]
+    rows.extend(
+        {
+            "date": dates[32 + j],
+            "ticker": "A",
+            "open": 100.0,
+            "high": 100.0 + float(d),
+            "low": 100.0 - float(d),
+            "close": 100.0,
+        }
+        for j, d in enumerate(range(1, 34))
+    )
+    bars = _compute_fair_value(_compute_ohlc4(_make_bars(rows)))
+    widths = _per_ticker_band_widths(bars)
+    rows = widths.filter(pl.col("ticker") == "A")
+    # The first valid SMA row sees only its own deviation, while the final
+    # row sees the complete historical set.
+    assert rows["n_straddling_bars"].to_list()[32:] == list(range(1, 34))
+    assert rows["upper_dev"][32] == pytest.approx(0.01, abs=1e-3)
+    assert rows["upper_dev"].tail(1)[0] == pytest.approx(0.17, abs=1e-3)
+    assert rows["lower_dev"].tail(1)[0] == pytest.approx(0.17, abs=1e-3)
+
+
+def test_zone_expression_classification() -> None:
+    """Vectorized zone classification: below / in / above the bands.
+
+    Boundary semantics: a close exactly equal to lower_band or upper_band
+    is treated as in_band (the threshold is exclusive).
+    """
+    df = pl.DataFrame(
+        {
+            "current_close": [9.0, 10.0, 11.0, 10.0, 13.0],
+            "lower_band": [10.0, 10.0, 10.0, 9.0, 11.0],
+            "upper_band": [11.0, 11.0, 11.0, 11.0, 12.0],
+        }
+    )
+    zones = df.with_columns(_zone_expression().alias("zone"))["zone"].to_list()
+    # close 9 < lower 10 → below_lower
+    assert zones[0] == ZONE_BELOW_LOWER
+    # close 10 == lower 10 → boundary is in_band (exclusive)
+    assert zones[1] == ZONE_IN_BAND
+    # close 11 == upper 11 → boundary is in_band
+    assert zones[2] == ZONE_IN_BAND
+    # close 10 with bands 9..11 → in_band
+    assert zones[3] == ZONE_IN_BAND
+    # close 13 > upper 12 → above_upper
+    assert zones[4] == ZONE_ABOVE_UPPER
+
+
+def _source_bands_df() -> pl.DataFrame:
+    """Build source bands with distinct values for as-of alignment tests."""
+    return pl.DataFrame(
+        {
+            "ticker": ["A", "A"],
+            "as_of_date": [datetime.date(2024, 1, 5), datetime.date(2024, 2, 10)],
+            "fair_value": [100.0, 200.0],
+            "upper_band": [110.0, 220.0],
+            "lower_band": [90.0, 180.0],
+            "current_close": [1.0, 1.0],
+            "upper_dev": [0.10, 0.20],
+            "lower_dev": [0.10, 0.20],
+            "n_straddling_bars": [3, 7],
+            "zone": [ZONE_BELOW_LOWER, ZONE_ABOVE_UPPER],
+            "bar_count": [40, 50],
+        },
+        schema=FAIR_VALUE_BANDS_SCHEMA,
+    )
+
+
+def test_align_fair_value_bands_weekly_display_uses_confirmed_monthly_source() -> None:
+    """Weekly bars use monthly bands from the following calendar month."""
+    display_bars = _make_bars(
+        [
+            {
+                "date": datetime.date(2024, 1, 31),
+                "ticker": "A",
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 85.0,
+            },
+            {
+                "date": datetime.date(2024, 2, 1),
+                "ticker": "A",
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 115.0,
+            },
+            {
+                "date": datetime.date(2024, 2, 2),
+                "ticker": "A",
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 105.0,
+            },
+            {
+                "date": datetime.date(2024, 2, 29),
+                "ticker": "A",
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 85.0,
+            },
+            {
+                "date": datetime.date(2024, 3, 1),
+                "ticker": "A",
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 230.0,
+            },
+        ]
+    )
+
+    result = align_fair_value_bands(_source_bands_df(), display_bars, "monthly")
+
+    assert dict(result.schema) == dict(FAIR_VALUE_BANDS_SCHEMA)
+    assert result["as_of_date"].to_list() == [
+        datetime.date(2024, 2, 1),
+        datetime.date(2024, 2, 2),
+        datetime.date(2024, 2, 29),
+        datetime.date(2024, 3, 1),
+    ]
+    assert result["fair_value"].to_list() == [100.0, 100.0, 100.0, 200.0]
+    assert result["current_close"].to_list() == [115.0, 105.0, 85.0, 230.0]
+    assert result["zone"].to_list() == [
+        ZONE_ABOVE_UPPER,
+        ZONE_IN_BAND,
+        ZONE_BELOW_LOWER,
+        ZONE_ABOVE_UPPER,
+    ]
+    assert result["n_straddling_bars"].to_list() == [3, 3, 3, 7]
+    assert result["bar_count"].to_list() == [40, 40, 40, 50]
+
+
+def test_align_fair_value_bands_daily_display_uses_confirmed_weekly_source() -> None:
+    """Daily closes drive zones after the following weekly bar begins."""
+    source = _source_bands_df().with_columns(
+        pl.Series(
+            "as_of_date",
+            [datetime.date(2024, 1, 3), datetime.date(2024, 1, 10)],
+        )
+    )
+    display_bars = _make_bars(
+        [
+            {
+                "date": datetime.date(2024, 1, 9),
+                "ticker": "A",
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 95.0,
+            },
+            {
+                "date": datetime.date(2024, 1, 10),
+                "ticker": "A",
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 115.0,
+            },
+            {
+                "date": datetime.date(2024, 1, 16),
+                "ticker": "A",
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 105.0,
+            },
+            {
+                "date": datetime.date(2024, 1, 17),
+                "ticker": "A",
+                "open": 100.0,
+                "high": 101.0,
+                "low": 99.0,
+                "close": 230.0,
+            },
+        ]
+    )
+
+    result = align_fair_value_bands(source, display_bars, "weekly")
+
+    assert result["as_of_date"].to_list() == [
+        datetime.date(2024, 1, 10),
+        datetime.date(2024, 1, 16),
+        datetime.date(2024, 1, 17),
+    ]
+    assert result["fair_value"].to_list() == [100.0, 100.0, 200.0]
+    assert result["current_close"].to_list() == [115.0, 105.0, 230.0]
+    assert result["zone"].to_list() == [
+        ZONE_ABOVE_UPPER,
+        ZONE_IN_BAND,
+        ZONE_ABOVE_UPPER,
+    ]
+
+
+def test_align_fair_value_bands_rejects_daily_source_timeframe() -> None:
+    """Only weekly and monthly native bands can be used as overlay sources."""
+    with pytest.raises(ValueError, match="source_timeframe must be one of"):
+        align_fair_value_bands(pl.DataFrame(), pl.DataFrame(), "daily")
+
+
+def test_compute_fair_value_bands_end_to_end() -> None:
+    """End-to-end: a ticker with a known median deviation produces known bands.
+
+    All bars have OHLC4 = 100 exactly (open=close=100, high=100+d,
+    low=100-d). fv = 100. All bars straddle fv. The upper_dev is d/100.
+
+    We use 65 bars: the first 32 are warmup (fv=null, not counted); the
+    remaining 33 are post-warmup and all straddle. d ∈ {1, 2, ..., 33},
+    so upper_dev = d/100 with median = 17/100 = 0.17.
+    """
+    dates = _dates(datetime.date(2020, 1, 1), 65)
+    zero_row = {
+        "ticker": "X",
+        "open": 100.0,
+        "high": 100.0,
+        "low": 100.0,
+        "close": 100.0,
+    }
+    rows = [{**zero_row, "date": dates[i]} for i in range(32)]
+    rows.extend(
+        {
+            "date": dates[32 + j],
+            "ticker": "X",
+            "open": 100.0,
+            "high": 100.0 + float(d),
+            "low": 100.0 - float(d),
+            "close": 100.0,
+        }
+        for j, d in enumerate(range(1, 34))
+    )
+    bars = _make_bars(rows)
+    result = compute_fair_value_bands(bars)
+    assert result.height == 33
+    first = result.row(0, named=True)
+    last = result.row(-1, named=True)
+    assert first["as_of_date"] == dates[32]
+    assert first["bar_count"] == 33
+    assert first["fair_value"] == pytest.approx(100.0, abs=0.01)
+    assert first["upper_dev"] == pytest.approx(0.01, abs=1e-3)
+    assert first["upper_band"] == pytest.approx(101.0, abs=0.05)
+    assert first["n_straddling_bars"] == 1
+    # The final row's expanding median sees all 33 deviations.
+    assert last["upper_dev"] == pytest.approx(0.17, abs=1e-3)
+    assert last["upper_band"] == pytest.approx(117.0, abs=0.05)
+    assert last["lower_dev"] == pytest.approx(0.17, abs=1e-3)
+    assert last["lower_band"] == pytest.approx(83.0, abs=0.05)
+    assert last["zone"] == ZONE_IN_BAND
+    assert last["bar_count"] == 65
+    # All 33 post-warmup bars straddle; the first 32 had fv=null.
+    assert last["n_straddling_bars"] == 33
+
+
+def test_compute_fair_value_bands_does_not_use_future_deviations() -> None:
+    """An earlier band's width is unaffected by a later extreme month."""
+    dates = _dates(datetime.date(2020, 1, 1), 34)
+    rows = [
+        {
+            "date": dates[i],
+            "ticker": "NOLEAK",
+            "open": 100.0,
+            "high": 101.0,
+            "low": 99.0,
+            "close": 100.0,
+        }
+        for i in range(33)
+    ]
+    rows.append(
+        {
+            "date": dates[-1],
+            "ticker": "NOLEAK",
+            "open": 100.0,
+            "high": 200.0,
+            "low": 0.0,
+            "close": 100.0,
+        }
+    )
+
+    result = compute_fair_value_bands(_make_bars(rows))
+    first = result.row(0, named=True)
+    later = result.row(-1, named=True)
+    assert first["as_of_date"] == dates[32]
+    assert first["upper_dev"] == pytest.approx(0.01, abs=1e-4)
+    assert first["upper_band"] == pytest.approx(101.0, abs=0.01)
+    assert later["upper_dev"] == pytest.approx(0.505, abs=1e-3)
+
+
+def test_compute_fair_value_bands_drops_under_warmup() -> None:
+    """Tickers with fewer than 33 monthly bars are excluded (SMA warmup)."""
+    dates = _dates(datetime.date(2024, 1, 1), 10)  # only 10 observations
+    rows = [
+        {
+            "date": dates[i],
+            "ticker": "SHORT",
+            "open": 100.0,
+            "high": 105.0,
+            "low": 95.0,
+            "close": 100.0,
+        }
+        for i in range(10)
+    ]
+    result = compute_fair_value_bands(_make_bars(rows))
+    assert result.is_empty()
+
+
+def test_compute_fair_value_bands_drops_no_straddles() -> None:
+    """Tickers whose bars never straddle the fair value are excluded.
+
+    Constant bars at 110 → OHLC4=110, fv=110, low=high=110 → no straddle.
+    """
+    dates = _dates(datetime.date(2020, 1, 1), 40)
+    rows = [
+        {
+            "date": dates[i],
+            "ticker": "CONST",
+            "open": 110.0,
+            "high": 110.0,
+            "low": 110.0,
+            "close": 110.0,
+        }
+        for i in range(40)
+    ]
+    result = compute_fair_value_bands(_make_bars(rows))
+    assert result.is_empty()
+
+
+def test_compute_fair_value_bands_zone_discount() -> None:
+    """A close below the lower band is classified as below_lower (discount)."""
+    dates = _dates(datetime.date(2020, 1, 1), 40)
+    # Build a ticker with 1% upper_dev, 1% lower_dev median. The last month
+    # has a very low close (95) so the close is below lower_band = 100 * 0.99 = 99.
+    base_row = {
+        "ticker": "D",
+        "open": 100.0,
+        "high": 101.0,
+        "low": 99.0,
+        "close": 100.0,
+    }
+    rows = [{**base_row, "date": dates[i]} for i in range(39)]
+    # Last month: a deep discount close.
+    rows.append(
+        {
+            "date": dates[39],
+            "ticker": "D",
+            "open": 95.0,
+            "high": 96.0,
+            "low": 90.0,
+            "close": 95.0,
+        }
+    )
+    result = compute_fair_value_bands(_make_bars(rows))
+    assert result.height == 8
+    assert result.row(-1, named=True)["zone"] == ZONE_BELOW_LOWER
+
+
+def test_compute_fair_value_bands_zone_premium() -> None:
+    """A close above the upper band is classified as above_upper (premium)."""
+    dates = _dates(datetime.date(2020, 1, 1), 40)
+    base_row = {
+        "ticker": "P",
+        "open": 100.0,
+        "high": 101.0,
+        "low": 99.0,
+        "close": 100.0,
+    }
+    rows = [{**base_row, "date": dates[i]} for i in range(39)]
+    # Last month: a deep premium close.
+    rows.append(
+        {
+            "date": dates[39],
+            "ticker": "P",
+            "open": 105.0,
+            "high": 110.0,
+            "low": 104.0,
+            "close": 105.0,
+        }
+    )
+    result = compute_fair_value_bands(_make_bars(rows))
+    assert result.height == 8
+    assert result.row(-1, named=True)["zone"] == ZONE_ABOVE_UPPER
+
+
+def test_compute_fair_value_bands_exactly_sma_period_bars() -> None:
+    """A ticker with exactly SMA_PERIOD monthly bars is included (warmup boundary)."""
+    dates = _dates(datetime.date(2020, 1, 1), SMA_PERIOD)
+    rows = [
+        {
+            "date": dates[i],
+            "ticker": "B",
+            "open": 100.0,
+            "high": 100.0 + float(i + 1),
+            "low": 100.0 - float(i + 1),
+            "close": 100.0,
+        }
+        for i in range(SMA_PERIOD)
+    ]
+    result = compute_fair_value_bands(_make_bars(rows))
+    # bar_count == SMA_PERIOD → eligible (>= SMA_PERIOD, off-by-one boundary).
+    assert result.height == 1
+    assert result.row(0, named=True)["bar_count"] == SMA_PERIOD
+    # With exactly 33 bars, fair_value is non-null only at the last row
+    # (the first 32 are warmup). So only 1 straddle is possible.
+    assert result.row(0, named=True)["n_straddling_bars"] == 1
+
+
+def test_compute_fair_value_bands_drops_fair_value_zero() -> None:
+    """A ticker whose fair value collapses to 0 is excluded (no div-by-zero)."""
+    dates = _dates(datetime.date(2020, 1, 1), 40)
+    # All bars are at price 0 → OHLC4 = 0 → SMA = 0 → fair_value = 0.
+    # The straddle filter (fair_value > 0) excludes all bars; the ticker
+    # is then dropped from the deviations table → final output is empty.
+    rows = [
+        {
+            "date": dates[i],
+            "ticker": "ZERO",
+            "open": 0.0,
+            "high": 0.0,
+            "low": 0.0,
+            "close": 0.0,
+        }
+        for i in range(40)
+    ]
+    result = compute_fair_value_bands(_make_bars(rows))
+    assert result.is_empty()
+
+
+def test_compute_fair_value_bands_handles_unsorted_input() -> None:
+    """Unsorted input is sorted internally; output is identical to sorted input."""
+    dates = _dates(datetime.date(2020, 1, 1), 40)
+    base_row = {
+        "ticker": "U",
+        "open": 100.0,
+        "high": 100.0 + 5.0,
+        "low": 100.0 - 5.0,
+        "close": 100.0,
+    }
+    rows_sorted = [{**base_row, "date": dates[i]} for i in range(40)]
+    # Shuffle deterministically using a fixed seed.
+    # ruff: noqa: S311  # random is fine for shuffling test data
+    import random
+
+    rng = random.Random(42)
+    rows_shuffled = rows_sorted.copy()
+    rng.shuffle(rows_shuffled)
+    sorted_result = compute_fair_value_bands(_make_bars(rows_sorted))
+    shuffled_result = compute_fair_value_bands(_make_bars(rows_shuffled, sort=False))
+    assert sorted_result.height == shuffled_result.height == 8
+    assert sorted_result.equals(shuffled_result)
+
+
+def test_compute_fair_value_bands_multi_ticker() -> None:
+    """Historical rows are sorted by ticker and then date."""
+    dates = _dates(datetime.date(2020, 1, 1), 40)
+    rows = [
+        {
+            "date": dates[i],
+            "ticker": ticker,
+            "open": 100.0,
+            "high": 101.0,
+            "low": 99.0,
+            "close": 100.0,
+        }
+        for ticker in ("AAA", "BBB", "CCC")
+        for i in range(40)
+    ]
+    result = compute_fair_value_bands(_make_bars(rows))
+    assert result.height == 24
+    assert result["ticker"].to_list() == [
+        ticker for ticker in ("AAA", "BBB", "CCC") for _ in range(8)
+    ]
+    assert (
+        result.filter(pl.col("ticker") == "BBB")["as_of_date"].to_list() == dates[32:]
+    )
+    pairs = list(
+        zip(result["ticker"].to_list(), result["as_of_date"].to_list(), strict=True)
+    )
+    assert pairs == sorted(pairs)
+
+
+def test_compute_fair_value_bands_schema_match() -> None:
+    """All supported timeframes produce the shared schema and same values."""
+    dates = _dates(datetime.date(2020, 1, 1), 40)
+    rows = [
+        {
+            "date": dates[i],
+            "ticker": "S",
+            "open": 100.0,
+            "high": 101.0,
+            "low": 99.0,
+            "close": 100.0,
+        }
+        for i in range(40)
+    ]
+    bars = _make_bars(rows)
+    results = [
+        compute_fair_value_bands(bars, timeframe)
+        for timeframe in ("daily", "weekly", "monthly")
+    ]
+    assert all(
+        dict(result.schema) == dict(FAIR_VALUE_BANDS_SCHEMA) for result in results
+    )
+    assert results[0].equals(results[1])
+    assert results[1].equals(results[2])
+
+
+def test_compute_fair_value_bands_rejects_invalid_timeframe() -> None:
+    """The algorithm rejects unsupported timeframe names deterministically."""
+    with pytest.raises(ValueError, match="timeframe must be one of"):
+        compute_fair_value_bands(pl.DataFrame(), "yearly")
+
+
+def test_as_of_date_is_last_monthly_bar() -> None:
+    """The final historical row uses the most recent monthly date and close."""
+    dates = _dates(datetime.date(2020, 1, 1), 40)
+    rows = [
+        {
+            "date": dates[i],
+            "ticker": "A",
+            "open": 100.0,
+            "high": 101.0,
+            "low": 99.0,
+            "close": 100.0,
+        }
+        for i in range(40)
+    ]
+    result = compute_fair_value_bands(_make_bars(rows))
+    assert result.row(-1, named=True)["as_of_date"] == dates[-1]
+    assert result.row(-1, named=True)["current_close"] == pytest.approx(100.0, abs=0.01)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -14,10 +14,12 @@ from tickerlake.load import (
     get_db_info,
     get_existing_dates,
     read_adjusted_daily_bars_for_ticker,
+    read_fair_value_bands,
     read_raw_db,
     read_splits,
     read_weekly_fib_zones,
     write_consumer_db,
+    write_fair_value_bands,
     write_raw_db,
     write_splits,
     write_weekly_fib_zones,
@@ -891,3 +893,115 @@ def test_read_weekly_fib_zones_missing_table(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="weekly_fib_zones table not found"):
         read_weekly_fib_zones(db_path)
+
+
+def _sample_fair_value_bands_df() -> pl.DataFrame:
+    """Build a small fair_value_bands DataFrame for load tests."""
+    from tickerlake.fair_value_bands import FAIR_VALUE_BANDS_SCHEMA
+
+    return pl.DataFrame(
+        {
+            "ticker": ["AAPL", "MSFT"],
+            "as_of_date": [datetime.date(2026, 8, 1), datetime.date(2026, 8, 1)],
+            "fair_value": [230.0, 410.0],
+            "upper_band": [270.0, 470.0],
+            "lower_band": [200.0, 360.0],
+            "current_close": [180.0, 500.0],
+            "upper_dev": [0.17, 0.15],
+            "lower_dev": [0.13, 0.12],
+            "n_straddling_bars": [33, 33],
+            "zone": ["below_lower", "above_upper"],
+            "bar_count": [66, 66],
+        },
+        schema=FAIR_VALUE_BANDS_SCHEMA,
+    )
+
+
+def test_write_fair_value_bands_creates_each_timeframe_table(tmp_path: Path) -> None:
+    """The generic writer creates the selected timeframe table."""
+    db_path = tmp_path / "test.duckdb"
+    for timeframe in ("daily", "weekly", "monthly"):
+        write_fair_value_bands(_sample_fair_value_bands_df(), db_path, timeframe)
+
+    con = duckdb.connect(str(db_path), read_only=True)
+    tables = {r[0] for r in con.execute("SHOW TABLES").fetchall()}
+    con.close()
+    assert {
+        "daily_fair_value_bands",
+        "weekly_fair_value_bands",
+        "monthly_fair_value_bands",
+    } <= tables
+
+
+def test_write_fair_value_bands_roundtrip(tmp_path: Path) -> None:
+    """The generic writer and reader round-trip each timeframe."""
+    db_path = tmp_path / "test.duckdb"
+    df = _sample_fair_value_bands_df()
+
+    for timeframe in ("daily", "weekly", "monthly"):
+        write_fair_value_bands(df, db_path, timeframe)
+        result = read_fair_value_bands(db_path, timeframe)
+        assert result.height == df.height
+        assert result["ticker"].to_list() == ["AAPL", "MSFT"]
+
+
+def test_read_fair_value_bands_sorts_history_by_ticker_and_date(
+    tmp_path: Path,
+) -> None:
+    """Historical rows are read in ticker/date order, not insertion order."""
+    df = _sample_fair_value_bands_df()
+    later = df.with_columns(
+        (pl.col("as_of_date") + pl.duration(days=31)).alias("as_of_date")
+    )
+    unsorted = pl.concat([later, df]).reverse()
+    db_path = tmp_path / "test.duckdb"
+
+    write_fair_value_bands(unsorted, db_path, "weekly")
+    result = read_fair_value_bands(db_path, "weekly")
+
+    pairs = list(
+        zip(result["ticker"].to_list(), result["as_of_date"].to_list(), strict=True)
+    )
+    assert pairs == sorted(pairs)
+
+
+def test_read_fair_value_bands_zone_filter(tmp_path: Path) -> None:
+    """The generic reader filters by zone (single string and list)."""
+    db_path = tmp_path / "test.duckdb"
+    write_fair_value_bands(_sample_fair_value_bands_df(), db_path, "daily")
+
+    below_lower = read_fair_value_bands(db_path, "daily", zone="below_lower")
+    assert below_lower.height == 1
+    assert below_lower["ticker"][0] == "AAPL"
+
+    both_extreme = read_fair_value_bands(
+        db_path, "daily", zone=["below_lower", "above_upper"]
+    )
+    assert both_extreme.height == 2
+
+
+def test_read_fair_value_bands_missing_file(tmp_path: Path) -> None:
+    """The generic reader rejects a missing consumer DB."""
+    db_path = tmp_path / "nonexistent.duckdb"
+    with pytest.raises(ValueError, match="Consumer DB not found"):
+        read_fair_value_bands(db_path, "monthly")
+
+
+def test_read_fair_value_bands_missing_table(tmp_path: Path) -> None:
+    """The generic reader identifies a missing selected timeframe table."""
+    db_path = tmp_path / "test.duckdb"
+    con = duckdb.connect(str(db_path))
+    con.execute("CREATE TABLE other_table (id INT)")
+    con.close()
+
+    with pytest.raises(ValueError, match="weekly_fair_value_bands table not found"):
+        read_fair_value_bands(db_path, "weekly")
+
+
+def test_fair_value_bands_rejects_invalid_timeframe(tmp_path: Path) -> None:
+    """Generic Fair Value Bands storage rejects invalid timeframes."""
+    db_path = tmp_path / "test.duckdb"
+    with pytest.raises(ValueError, match="timeframe must be one of"):
+        write_fair_value_bands(_sample_fair_value_bands_df(), db_path, "yearly")
+    with pytest.raises(ValueError, match="timeframe must be one of"):
+        read_fair_value_bands(db_path, "yearly")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1695,3 +1695,474 @@ def test_screen_fib_zones_missing_db(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="Consumer DB not found"):
         pipeline.screen_fib_zones(config, zone="all")
+
+
+# ---------------------------------------------------------------------------
+# Fair Value Bands
+# ---------------------------------------------------------------------------
+
+
+def _build_consumer_db_with_bars(
+    tmp_path: Path, bars: pl.DataFrame, timeframe: str
+) -> Path:
+    """Create a consumer DuckDB with bars at one selected timeframe."""
+    from tickerlake.load import write_consumer_db
+
+    daily_bars = pl.DataFrame(
+        schema={
+            "date": pl.Date,
+            "ticker": pl.Utf8,
+            "open": pl.Float32,
+            "high": pl.Float32,
+            "low": pl.Float32,
+            "close": pl.Float32,
+            "volume": pl.Float32,
+            "vwap": pl.Float32,
+            "transactions": pl.UInt32,
+        }
+    )
+    if timeframe == "daily":
+        daily_bars = bars
+    daily_metrics = pl.DataFrame(
+        schema={
+            "date": pl.Date,
+            "ticker": pl.Utf8,
+            "sma_20": pl.Float32,
+            "sma_50": pl.Float32,
+            "sma_200": pl.Float32,
+            "atr_14": pl.Float32,
+            "atr_pct": pl.Float32,
+            "adr_pct": pl.Float32,
+            "volume_sma_20": pl.Float32,
+        }
+    )
+    tickers = pl.DataFrame(
+        {
+            "ticker": ["AAPL", "MSFT"],
+            "name": ["Apple Inc.", "Microsoft Corp."],
+            "type": ["CS", "CS"],
+            "primary_exchange": ["XNAS", "XNAS"],
+            "cik": ["", ""],
+            "active": [True, True],
+        }
+    )
+    db = tmp_path / "tickerlake.duckdb"
+    if timeframe == "daily":
+        timeframe_bars = {"weekly_bars": bars}
+    elif timeframe == "weekly":
+        timeframe_bars = {"weekly_bars": bars, "monthly_bars": bars}
+    else:
+        timeframe_bars = {"monthly_bars": bars}
+    write_consumer_db(daily_bars, daily_metrics, tickers, db, **timeframe_bars)
+    return db
+
+
+def _bars_df(ticker: str = "AAPL", n: int = 40) -> pl.DataFrame:
+    """Build simple bars for Fair Value Bands pipeline tests."""
+    dates = [
+        datetime.date(2020, 1, 1) + datetime.timedelta(days=30 * i) for i in range(n)
+    ]
+    return pl.DataFrame(
+        {
+            "date": dates,
+            "ticker": [ticker] * n,
+            "open": [100.0] * n,
+            "high": [105.0] * n,
+            "low": [95.0] * n,
+            "close": [100.0] * n,
+            "volume": [1_000_000.0] * n,
+            "vwap": [100.0] * n,
+            "transactions": [100] * n,
+        }
+    ).with_columns(
+        pl.col("date").cast(pl.Date),
+        pl.col("ticker").cast(pl.Utf8),
+        pl.col("open").cast(pl.Float32),
+        pl.col("high").cast(pl.Float32),
+        pl.col("low").cast(pl.Float32),
+        pl.col("close").cast(pl.Float32),
+        pl.col("volume").cast(pl.Float32),
+        pl.col("vwap").cast(pl.Float32),
+        pl.col("transactions").cast(pl.UInt32),
+    )
+
+
+def test_compute_fair_value_bands_writes_rows(tmp_path: Path, caplog) -> None:
+    """compute_fair_value_bands persists computed bands to the selected table."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    _build_consumer_db_with_bars(tmp_path, _bars_df(), "monthly")
+
+    with caplog.at_level("INFO"):
+        pipeline.compute_fair_value_bands(config, "monthly")
+
+    db = tmp_path / "tickerlake.duckdb"
+    con = duckdb.connect(str(db), read_only=True)
+    try:
+        rows = con.execute(
+            "SELECT ticker, as_of_date, zone FROM monthly_fair_value_bands"
+        ).fetchall()
+    finally:
+        con.close()
+
+    assert len(rows) == 8
+    assert {row[0] for row in rows} == {"AAPL"}
+    assert [row[1] for row in rows] == sorted(row[1] for row in rows)
+    assert "n_written=8" in caplog.text
+    assert "n_below_lower=0" in caplog.text
+    assert "n_excluded=0" in caplog.text
+
+
+def test_compute_fair_value_bands_missing_db(tmp_path: Path) -> None:
+    """compute raises ValueError when the consumer DB is absent."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+
+    with pytest.raises(ValueError, match="Consumer DB not found"):
+        pipeline.compute_fair_value_bands(config, "monthly")
+
+
+@pytest.mark.parametrize("timeframe", ["daily", "weekly", "monthly"])
+def test_compute_fair_value_bands_uses_matching_bars_table(
+    tmp_path: Path, timeframe: str
+) -> None:
+    """compute reads source bars and writes the selected display table."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    bars = _bars_df()
+    _build_consumer_db_with_bars(tmp_path, bars, timeframe)
+    from tickerlake.fair_value_bands import compute_fair_value_bands as algorithm
+
+    with (
+        patch(
+            f"{_PIPELINE}._compute_native_fair_value_bands", wraps=algorithm
+        ) as compute,
+        patch(
+            f"{_PIPELINE}._read_fair_value_bands_bars",
+            wraps=pipeline._read_fair_value_bands_bars,
+        ) as read_bars,
+        patch(
+            f"{_PIPELINE}._align_fair_value_bands",
+            wraps=pipeline._align_fair_value_bands,
+        ) as align,
+    ):
+        pipeline.compute_fair_value_bands(config, timeframe)
+
+    compute.assert_called_once()
+    source_timeframe = "weekly" if timeframe == "daily" else "monthly"
+    assert compute.call_args.args[0].equals(bars)
+    expected_reads = (
+        [timeframe]
+        if timeframe == "monthly"
+        else [
+            timeframe,
+            source_timeframe,
+        ]
+    )
+    assert [call.args[1] for call in read_bars.call_args_list] == expected_reads
+    if timeframe == "monthly":
+        align.assert_not_called()
+    else:
+        assert align.call_args.args[2] == source_timeframe
+    con = duckdb.connect(str(tmp_path / "tickerlake.duckdb"), read_only=True)
+    try:
+        tables = {row[0] for row in con.execute("SHOW TABLES").fetchall()}
+    finally:
+        con.close()
+    assert f"{timeframe}_fair_value_bands" in tables
+
+
+@pytest.mark.parametrize("timeframe", ["daily", "weekly", "monthly"])
+def test_compute_fair_value_bands_missing_matching_table(
+    tmp_path: Path, timeframe: str
+) -> None:
+    """compute raises ValueError when the selected bars table is absent."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    db = tmp_path / "tickerlake.duckdb"
+    con = duckdb.connect(str(db))
+    con.execute("CREATE TABLE unrelated (x INT)")
+    con.close()
+
+    with pytest.raises(ValueError, match=f"{timeframe}_bars"):
+        pipeline.compute_fair_value_bands(config, timeframe)
+
+
+def test_compute_fair_value_bands_rejects_invalid_timeframe(tmp_path: Path) -> None:
+    """compute rejects invalid timeframes before opening the consumer DB."""
+    from tickerlake import pipeline
+
+    with pytest.raises(ValueError, match="timeframe must be one of"):
+        pipeline.compute_fair_value_bands(_make_config(tmp_path), "yearly")
+
+
+def test_compute_fair_value_bands_rejects_bad_schema(tmp_path: Path) -> None:
+    """compute rejects a malformed compute result."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    _build_consumer_db_with_bars(tmp_path, _bars_df(), "monthly")
+
+    def _bad_compute_result(*args, **kwargs) -> pl.DataFrame:
+        # Simulate compute returning a DataFrame missing a required column.
+        return pl.DataFrame(
+            {"ticker": ["AAPL"], "as_of_date": [datetime.date(2024, 1, 1)]}
+        )
+
+    with (
+        patch(
+            f"{_PIPELINE}._compute_native_fair_value_bands",
+            side_effect=_bad_compute_result,
+        ),
+        pytest.raises(ValueError, match="monthly_fair_value_bands schema mismatch"),
+    ):
+        pipeline.compute_fair_value_bands(config, "monthly")
+
+
+def _write_fair_value_bands_table(
+    db_path: Path, df: pl.DataFrame, timeframe: str = "monthly"
+) -> None:
+    """Create/replace one timeframe Fair Value Bands table from a DataFrame."""
+    table = {
+        "daily": "daily_fair_value_bands",
+        "weekly": "weekly_fair_value_bands",
+        "monthly": "monthly_fair_value_bands",
+    }[timeframe]
+    with tempfile.NamedTemporaryFile(suffix=".parquet", delete=False) as f:
+        tmp = Path(f.name)
+    try:
+        df.write_parquet(tmp)
+        con = duckdb.connect(str(db_path))
+        try:
+            con.execute(
+                f"CREATE OR REPLACE TABLE {table} AS "  # noqa: S608
+                "SELECT * FROM read_parquet(?)",
+                [str(tmp)],
+            )
+        finally:
+            con.close()
+    finally:
+        tmp.unlink(missing_ok=True)
+
+
+def _fvb_df() -> pl.DataFrame:
+    """Monthly fair value bands rows in deliberately non-sorted ticker order."""
+    from tickerlake.fair_value_bands import FAIR_VALUE_BANDS_SCHEMA
+
+    def row(
+        ticker: str, close: float, fv: float, zone: str, n_straddling: int = 33
+    ) -> dict:
+        return {
+            "ticker": ticker,
+            "as_of_date": datetime.date(2024, 1, 1),
+            "fair_value": fv,
+            "upper_band": fv * 1.10,
+            "lower_band": fv * 0.90,
+            "current_close": close,
+            "upper_dev": 0.10,
+            "lower_dev": 0.10,
+            "n_straddling_bars": n_straddling,
+            "zone": zone,
+            "bar_count": 66,
+        }
+
+    return pl.DataFrame(
+        [
+            row("NVDA", 50.0, 100.0, "below_lower"),
+            row("SPY", 150.0, 100.0, "above_upper"),
+            row("AAPL", 80.0, 100.0, "below_lower"),
+            row("TSLA", 200.0, 100.0, "above_upper"),
+            row("MSFT", 100.0, 100.0, "in_band"),
+        ],
+        schema=FAIR_VALUE_BANDS_SCHEMA,
+    )
+
+
+def test_screen_monthly_fair_value_bands_all_default(tmp_path: Path, caplog) -> None:
+    """zone=all shows actionable zones and hides in_band rows."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    _write_fair_value_bands_table(tmp_path / "tickerlake.duckdb", _fvb_df())
+    recording = Console(record=True)
+
+    with (
+        patch(f"{_PIPELINE}.console", recording),
+        caplog.at_level("INFO"),
+    ):
+        pipeline.screen_fair_value_bands(config, "monthly", zone="all")
+
+    text = recording.export_text()
+    assert "as_of_date" in text
+    assert "2024-01-01" in text
+    assert "AAPL" in text
+    assert "NVDA" in text
+    assert "SPY" in text
+    assert "TSLA" in text
+    assert "MSFT" not in text  # in_band is not actionable
+    assert "4 total matches" in caplog.text
+
+
+@pytest.mark.parametrize("timeframe", ["daily", "weekly", "monthly"])
+def test_screen_fair_value_bands_title_uses_timeframe(
+    tmp_path: Path, timeframe: str
+) -> None:
+    """Screen title identifies the selected timeframe."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    _write_fair_value_bands_table(tmp_path / "tickerlake.duckdb", _fvb_df(), timeframe)
+    recording = Console(record=True)
+
+    with patch(f"{_PIPELINE}.console", recording):
+        pipeline.screen_fair_value_bands(config, timeframe, zone="below_lower")
+
+    assert (
+        f"{timeframe.capitalize()} fair value bands screen" in recording.export_text()
+    )
+
+
+def test_screen_monthly_fair_value_bands_zone_filter(tmp_path: Path) -> None:
+    """Explicit --zone filters to a single zone."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    _write_fair_value_bands_table(tmp_path / "tickerlake.duckdb", _fvb_df())
+    recording = Console(record=True)
+
+    with patch(f"{_PIPELINE}.console", recording):
+        pipeline.screen_fair_value_bands(config, "monthly", zone="below_lower")
+
+    text = recording.export_text()
+    assert "AAPL" in text
+    assert "NVDA" in text
+    assert "SPY" not in text
+    assert "TSLA" not in text
+
+
+def test_screen_monthly_fair_value_bands_zone_in_band(tmp_path: Path) -> None:
+    """zone="in_band" filters to the neutral zone (excluded from zone='all')."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    _write_fair_value_bands_table(tmp_path / "tickerlake.duckdb", _fvb_df())
+    recording = Console(record=True)
+
+    with patch(f"{_PIPELINE}.console", recording):
+        pipeline.screen_fair_value_bands(config, "monthly", zone="in_band")
+
+    text = recording.export_text()
+    # Only MSFT is in_band; all other tickers are excluded.
+    assert "MSFT" in text
+    assert "AAPL" not in text
+    assert "NVDA" not in text
+    assert "SPY" not in text
+    assert "TSLA" not in text
+
+
+def test_screen_monthly_fair_value_bands_min_close_filter(tmp_path: Path) -> None:
+    """--min-close excludes rows below the threshold."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    _write_fair_value_bands_table(tmp_path / "tickerlake.duckdb", _fvb_df())
+    recording = Console(record=True)
+
+    with patch(f"{_PIPELINE}.console", recording):
+        pipeline.screen_fair_value_bands(config, "monthly", zone="all", min_close=100.0)
+
+    text = recording.export_text()
+    # AAPL close=80, NVDA close=50 → excluded by min_close=100.
+    assert "AAPL" not in text
+    assert "NVDA" not in text
+    assert "SPY" in text
+    assert "TSLA" in text
+
+
+def test_screen_monthly_fair_value_bands_min_close_excludes_all(
+    tmp_path: Path, caplog
+) -> None:
+    """--min-close above all rows produces an empty screen."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    _write_fair_value_bands_table(tmp_path / "tickerlake.duckdb", _fvb_df())
+    recording = Console(record=True)
+
+    with (
+        patch(f"{_PIPELINE}.console", recording),
+        caplog.at_level("INFO"),
+    ):
+        pipeline.screen_fair_value_bands(config, "monthly", zone="all", min_close=300.0)
+
+    text = recording.export_text()
+    # No ticker rows should appear in the table.
+    for ticker in ("AAPL", "MSFT", "NVDA", "SPY", "TSLA"):
+        assert ticker not in text
+    assert "0 total matches" in caplog.text
+    assert "0 displayed" in caplog.text
+
+
+def test_screen_monthly_fair_value_bands_limit(tmp_path: Path, caplog) -> None:
+    """--limit caps the number of rows displayed."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    _write_fair_value_bands_table(tmp_path / "tickerlake.duckdb", _fvb_df())
+    recording = Console(record=True)
+
+    with (
+        patch(f"{_PIPELINE}.console", recording),
+        caplog.at_level("INFO"),
+    ):
+        pipeline.screen_fair_value_bands(config, "monthly", zone="all", limit=2)
+
+    text = recording.export_text()
+    assert "2 displayed" in caplog.text
+    assert "4 total matches" in caplog.text
+    # Two ticker rows should appear in the table (cap at 2 of 4).
+    # Count by ticker symbol rather than zone (which may be truncated).
+    ticker_rows = sum(1 for t in ("AAPL", "MSFT", "NVDA", "SPY", "TSLA") if t in text)
+    assert ticker_rows == 2
+
+
+def test_screen_monthly_fair_value_bands_sorted_by_ticker(tmp_path: Path) -> None:
+    """Screen output is sorted by ticker even when the table is unsorted."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    _write_fair_value_bands_table(tmp_path / "tickerlake.duckdb", _fvb_df())
+    recording = Console(record=True)
+
+    with patch(f"{_PIPELINE}.console", recording):
+        pipeline.screen_fair_value_bands(config, "monthly", zone="below_lower")
+
+    text = recording.export_text()
+    assert text.index("AAPL") < text.index("NVDA")
+
+
+def test_screen_monthly_fair_value_bands_missing_table(tmp_path: Path) -> None:
+    """screen_monthly_fair_value_bands raises ValueError when the table is absent."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+    db = tmp_path / "tickerlake.duckdb"
+    con = duckdb.connect(str(db))
+    con.close()
+
+    with pytest.raises(ValueError, match="monthly_fair_value_bands"):
+        pipeline.screen_fair_value_bands(config, "monthly", zone="all")
+
+
+def test_screen_monthly_fair_value_bands_missing_db(tmp_path: Path) -> None:
+    """screen raises ValueError when the consumer DB is absent."""
+    from tickerlake import pipeline
+
+    config = _make_config(tmp_path)
+
+    with pytest.raises(ValueError, match="Consumer DB not found"):
+        pipeline.screen_fair_value_bands(config, "monthly", zone="all")


### PR DESCRIPTION
## Summary

- Add Fair Value Bands using a 33-period OHLC4 SMA with expanding median-deviation bands.
- Persist separate daily, weekly, and monthly bands tables, with commands to compute and screen each display timeframe.
- Match AIQ confirmation behavior: daily rows use confirmed weekly values, weekly rows use confirmed monthly values, and monthly rows use native monthly values.

## Test plan

- `make check` passes: 320 tests, 99.14% coverage, Ruff lint/format, and Xenon complexity checks.
- Verified the AIQ exports: daily, weekly, and monthly fair values match within Float32 precision.
- CodeRabbit local review timed out after 90 seconds without producing findings.
