### PR TITLE
feat(fib-zones): remove lookback cap

### DIFF
--- a/src/tickerlake/fib_zones.py
+++ b/src/tickerlake/fib_zones.py
@@ -6,8 +6,6 @@ then computes the Institutional Buying Zone (IBZ, 0.618-0.786 retracement)
 and Smart Money Zone (SMZ, 0.786-0.826 retracement) for that leg.
 
 Algorithm:
-    0. Restrict bars to the most recent max_lookback_years (default 2
-       years) — legs anchored on older pivot lows are ignored.
     1. Detect k-bar fractal pivots on weekly bars (a bar is a pivot high
        if it's higher than k bars on each side; similarly for pivot low).
     2. Walk pivot lows from most recent to oldest.
@@ -29,13 +27,9 @@ Public API:
 
 from __future__ import annotations
 
-import datetime
-
 import polars as pl
 
 from tickerlake.transform import find_pivots
-
-DEFAULT_MAX_LOOKBACK_YEARS: int = 2
 
 # Public schema — used by load.py.
 WEEKLY_FIB_ZONES_SCHEMA: dict = {
@@ -244,7 +238,6 @@ def compute_fib_zones_for_ticker(
     k: int = 4,
     min_leg_pct: float = 0.20,
     min_bars_between_pivots: int = 5,
-    max_lookback_years: int | None = DEFAULT_MAX_LOOKBACK_YEARS,
 ) -> dict | None:
     """Compute fib zones for the most recent unswept major leg on weekly bars.
 
@@ -252,9 +245,9 @@ def compute_fib_zones_for_ticker(
     on the most recent pivot low and pairs it with the highest pivot high
     that came at least `min_bars_between_pivots` weeks later.
 
-    Bars are first restricted to the most recent `max_lookback_years` (default
-    2 years; pass None to disable the cap), so the leg's swing low cannot be
-    older than that window.
+    All available weekly bars are considered — there is no lookback cap, so
+    the leg's swing low can be any age as long as the swing structure is
+    valid and unswept.
 
     Returns a flat dict matching WEEKLY_FIB_ZONES_SCHEMA keys, or None
     when no valid unswept leg exists.
@@ -269,16 +262,11 @@ def compute_fib_zones_for_ticker(
         min_bars_between_pivots: minimum number of weekly bars between
             the swing low and the swing high. Default 5 — filters out
             legs where the pivots are too close together in time.
-        max_lookback_years: maximum age of bars considered, capped at this
-            many years before the last bar. Default 2.
     """
     if bars is None or bars.is_empty():
         return None
 
     sorted_df = bars.sort("date")
-    if max_lookback_years is not None:
-        cutoff = datetime.timedelta(days=365 * max_lookback_years)
-        sorted_df = sorted_df.filter(pl.col("date") >= pl.col("date").max() - cutoff)
     bar_dicts = sorted_df.select(["date", "high", "low", "close"]).to_dicts()
     if not bar_dicts:
         return None

--- a/src/tickerlake/pipeline.py
+++ b/src/tickerlake/pipeline.py
@@ -430,8 +430,8 @@ def compute_weekly_fib_zones(config: Config) -> None:
     """Compute weekly fib zones for all eligible tickers and persist them.
 
     Eligible tickers are those whose latest weekly_metrics row has
-    volume_sma_20 >= _LIQUIDITY_VOLUME_THRESHOLD. The lookback is capped at
-    the most recent 2 years of weekly bars (see fib_zones.DEFAULT_MAX_LOOKBACK_YEARS).
+    volume_sma_20 >= _LIQUIDITY_VOLUME_THRESHOLD. All available weekly bars
+    are considered (no lookback cap).
     Logs the number of eligible tickers, per-zone counts, void count, and
     rows written.
     """

--- a/tests/test_fib_zones.py
+++ b/tests/test_fib_zones.py
@@ -122,9 +122,8 @@ def test_compute_fib_zones_v_shape() -> None:
     assert result["swing_high"] == 30.0
 
 
-def test_compute_fib_zones_lookback_drops_old_leg() -> None:
-    """A valid leg whose swing low is older than the 2-year lookback is
-    ignored; disabling the lookback finds it."""
+def test_compute_fib_zones_keeps_old_unswept_leg() -> None:
+    """A valid old leg remains eligible after 100 later weekly bars."""
     v_highs = [
         20.0,
         18.0,
@@ -164,64 +163,11 @@ def test_compute_fib_zones_lookback_drops_old_leg() -> None:
     bars = _make_bars(
         v_highs + tail_highs, v_lows + tail_lows, datetime.date(2023, 1, 1)
     )
-    assert (
-        compute_fib_zones_for_ticker(
-            bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=2
-        )
-        is None
-    )
-    result = compute_fib_zones_for_ticker(
-        bars,
-        k=3,
-        min_leg_pct=0.20,
-        min_bars_between_pivots=2,
-        max_lookback_years=None,
-    )
-    assert result is not None
-    assert result["swing_low"] == 8.0
-    assert result["swing_high"] == 30.0
 
-
-def test_compute_fib_zones_lookback_keeps_recent_leg() -> None:
-    """A leg whose swing low is within the lookback window is still found."""
-    highs = [
-        20.0,
-        18.0,
-        15.0,
-        12.0,
-        11.0,
-        10.0,
-        10.0,
-        14.0,
-        20.0,
-        25.0,
-        30.0,
-        28.0,
-        24.0,
-        20.0,
-        14.0,
-    ]
-    lows = [
-        18.0,
-        15.0,
-        12.0,
-        10.0,
-        9.0,
-        8.0,
-        8.0,
-        12.0,
-        18.0,
-        22.0,
-        28.0,
-        25.0,
-        21.0,
-        18.0,
-        12.0,
-    ]
-    bars = _make_bars(highs, lows, datetime.date(2025, 1, 1))
     result = compute_fib_zones_for_ticker(
         bars, k=3, min_leg_pct=0.20, min_bars_between_pivots=2
     )
+
     assert result is not None
     assert result["swing_low"] == 8.0
     assert result["swing_high"] == 30.0


### PR DESCRIPTION
## Summary

- Remove the two-year lookback cap from weekly Fib Zone leg selection.
- Allow the most recent valid unswept leg to remain eligible regardless of its swing-low age.
- Keep a regression test covering an old leg with 100 later weekly bars.

## Test plan

- `make check` passes: 259 tests, 99.40% coverage, Ruff lint/format, and Xenon complexity checks.
- CodeRabbit local review completed with 0 findings.
