### PR TITLE
feat: color and emoji the etf-race leaderboard

### DIFF
--- a/docs/etf-race.md
+++ b/docs/etf-race.md
@@ -65,6 +65,22 @@ already in front from horses closing ground: front-runners score well on
 leadership and staying power, while chargers score well on places gained and
 recent pace.
 
+### Reading the table
+
+The table uses color and emoji so the state of the field is scannable at a
+glance:
+
+- **Form column** — each horse gets an emoji and its whole row is tinted:
+  🚀 `Charging` (green), 🏆 `Front-runner` (cyan), ⚡ `Closing ground`
+  (yellow), ➖ `Steady` (no tint), 📉 `Losing steam` (red), 🍂 `Fading`
+  (orange), 🐢 `Back of field` (dim red), ❔ `Unknown` (dim).
+- **Pace columns** — green when the pace is positive (outperforming the
+  benchmark), red when negative.
+- **Race column** — green for scores ≥ 70, yellow for 40–69, red for < 40.
+
+Colors are ANSI and are disabled automatically by Rich when the output is
+not a terminal; emoji remain plain text.
+
 ## Methodology
 
 ### vs-Benchmark Momentum

--- a/src/tickerlake/race.py
+++ b/src/tickerlake/race.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING
 import duckdb
 import polars as pl
 from rich.table import Table
+from rich.text import Text
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -696,19 +697,36 @@ def render_relative_leaderboard(
         )
 
     for row in sorted_df.iter_rows(named=True):
+        emoji, row_style = _form_style(row.get("form"))
+        form_label = row.get("form") or "Unknown"
         table.add_row(
             row["ticker"],
             _fmt_or_na(row.get("position"), lambda value: str(int(value))),
             _fmt_or_na(row.get("places_gained"), lambda value: f"{int(value):+d}"),
-            _fmt_or_na(
-                row.get("relative_return_short"), lambda value: f"{value:+.1f}%"
+            Text(
+                _fmt_or_na(
+                    row.get("relative_return_short"), lambda value: f"{value:+.1f}%"
+                ),
+                style=_pace_style(row.get("relative_return_short")),
             ),
-            _fmt_or_na(
-                row.get("relative_return_medium"), lambda value: f"{value:+.1f}%"
+            Text(
+                _fmt_or_na(
+                    row.get("relative_return_medium"), lambda value: f"{value:+.1f}%"
+                ),
+                style=_pace_style(row.get("relative_return_medium")),
             ),
-            _fmt_or_na(row.get("relative_return_long"), lambda value: f"{value:+.1f}%"),
-            _fmt_or_na(row.get("race_score"), lambda value: f"{value:.0f}"),
-            row.get("form") or "Unknown",
+            Text(
+                _fmt_or_na(
+                    row.get("relative_return_long"), lambda value: f"{value:+.1f}%"
+                ),
+                style=_pace_style(row.get("relative_return_long")),
+            ),
+            Text(
+                _fmt_or_na(row.get("race_score"), lambda value: f"{value:.0f}"),
+                style=_race_score_style(row.get("race_score")),
+            ),
+            f"{emoji} {form_label}",
+            style=row_style,
         )
 
     return table

--- a/src/tickerlake/race.py
+++ b/src/tickerlake/race.py
@@ -707,23 +707,23 @@ def render_relative_leaderboard(
                 _fmt_or_na(
                     row.get("relative_return_short"), lambda value: f"{value:+.1f}%"
                 ),
-                style=_pace_style(row.get("relative_return_short")),
+                style=_pace_style(row.get("relative_return_short")),  # ty: ignore[invalid-argument-type]
             ),
             Text(
                 _fmt_or_na(
                     row.get("relative_return_medium"), lambda value: f"{value:+.1f}%"
                 ),
-                style=_pace_style(row.get("relative_return_medium")),
+                style=_pace_style(row.get("relative_return_medium")),  # ty: ignore[invalid-argument-type]
             ),
             Text(
                 _fmt_or_na(
                     row.get("relative_return_long"), lambda value: f"{value:+.1f}%"
                 ),
-                style=_pace_style(row.get("relative_return_long")),
+                style=_pace_style(row.get("relative_return_long")),  # ty: ignore[invalid-argument-type]
             ),
             Text(
                 _fmt_or_na(row.get("race_score"), lambda value: f"{value:.0f}"),
-                style=_race_score_style(row.get("race_score")),
+                style=_race_score_style(row.get("race_score")),  # ty: ignore[invalid-argument-type]
             ),
             f"{emoji} {form_label}",
             style=row_style,

--- a/src/tickerlake/race.py
+++ b/src/tickerlake/race.py
@@ -107,6 +107,25 @@ _DEFAULT_MAX_PENDING_OVERTAKES = 25
 _RS_RATIO_BASELINE = 100.0
 _MIN_PLACES_TO_CHARGE = 2
 
+# Rendering styles for the horse-race leaderboard: form label -> (emoji,
+# row style). The emoji is shown in the Form cell; the style tints the whole
+# row. Style is None for forms that render unstyled.
+FORM_STYLE: dict[str, tuple[str, str | None]] = {
+    "Charging": ("🚀", "green"),
+    "Front-runner": ("🏆", "cyan"),
+    "Closing ground": ("⚡", "yellow"),
+    "Steady": ("➖", None),  # noqa: RUF001 -- deliberate per design spec
+    "Losing steam": ("📉", "red"),
+    "Fading": ("🍂", "orange"),
+    "Back of field": ("🐢", "dim red"),
+    "Unknown": ("❔", "dim"),
+}
+
+# Race-score color buckets: >= _RACE_SCORE_HIGH is green, >= _RACE_SCORE_LOW
+# is yellow, below is red.
+_RACE_SCORE_HIGH = 70.0
+_RACE_SCORE_LOW = 40.0
+
 
 def read_race_bars(
     consumer_path: Path,
@@ -622,6 +641,29 @@ def classify_horse_form(metrics: pl.DataFrame) -> pl.DataFrame:
 def _fmt_or_na(value: float | None, formatter: Callable[[float], str]) -> str:
     """Format a value using the given formatter, or return 'n/a' if null."""
     return "n/a" if value is None else formatter(value)
+
+
+def _form_style(form: str | None) -> tuple[str, str | None]:
+    """Return (emoji, row style) for a horse form; Unknown for null/unknown."""
+    return FORM_STYLE.get(form, FORM_STYLE["Unknown"])
+
+
+def _pace_style(value: float | None) -> str | None:
+    """Return a Rich style for a pace value: green for gains, red for losses."""
+    if value is None or value == 0:
+        return None
+    return "green" if value > 0 else "red"
+
+
+def _race_score_style(value: float | None) -> str | None:
+    """Return a Rich style for a race score bucket (green/yellow/red)."""
+    if value is None:
+        return None
+    if value >= _RACE_SCORE_HIGH:
+        return "green"
+    if value >= _RACE_SCORE_LOW:
+        return "yellow"
+    return "red"
 
 
 def render_relative_leaderboard(

--- a/tests/test_race.py
+++ b/tests/test_race.py
@@ -1284,3 +1284,37 @@ def test_render_relative_leaderboard_null_safe():
     assert "UNKNOWN" in text
     assert "Unknown" in text
     assert "n/a" in text  # Null rs_ratio rendered as "n/a"
+
+
+def test_form_style_maps_all_forms():
+    assert race.FORM_STYLE == {
+        "Charging": ("🚀", "green"),
+        "Front-runner": ("🏆", "cyan"),
+        "Closing ground": ("⚡", "yellow"),
+        "Steady": ("➖", None),  # noqa: RUF001 -- deliberate per design spec
+        "Losing steam": ("📉", "red"),
+        "Fading": ("🍂", "orange"),
+        "Back of field": ("🐢", "dim red"),
+        "Unknown": ("❔", "dim"),
+    }
+
+
+def test_form_style_falls_back_to_unknown():
+    assert race._form_style(None) == ("❔", "dim")
+    assert race._form_style("Not a form") == ("❔", "dim")
+
+
+def test_pace_style_sign_coloring():
+    assert race._pace_style(2.0) == "green"
+    assert race._pace_style(-0.5) == "red"
+    assert race._pace_style(0.0) is None
+    assert race._pace_style(None) is None
+
+
+def test_race_score_style_buckets():
+    assert race._race_score_style(88.0) == "green"
+    assert race._race_score_style(70.0) == "green"
+    assert race._race_score_style(55.0) == "yellow"
+    assert race._race_score_style(40.0) == "yellow"
+    assert race._race_score_style(39.9) == "red"
+    assert race._race_score_style(None) is None

--- a/tests/test_race.py
+++ b/tests/test_race.py
@@ -310,6 +310,15 @@ def _rich_text(table) -> str:
     return console.export_text()
 
 
+def _rich_ansi(table) -> str:
+    """Render a Rich Table to ANSI text so style assertions can inspect it."""
+    from rich.console import Console
+
+    console = Console(record=True, width=200, force_terminal=False)
+    console.print(table)
+    return console.export_text(styles=True)
+
+
 # ---- detect_pending_overtakes ---------------------------------------------
 
 
@@ -1318,3 +1327,77 @@ def test_race_score_style_buckets():
     assert race._race_score_style(40.0) == "yellow"
     assert race._race_score_style(39.9) == "red"
     assert race._race_score_style(None) is None
+
+
+def test_render_relative_leaderboard_applies_form_emoji_and_row_styles():
+    """The Form column shows emoji and each row is tinted by its form."""
+    metrics = pl.DataFrame(
+        {
+            "ticker": ["CHARGER", "FRONTRUNNER", "STEADY", "LOSER"],
+            "position": [2, 1, 4, 5],
+            "places_gained": [5, 1, 0, -3],
+            "relative_return_short": [2.0, 1.0, 0.5, -2.0],
+            "relative_return_medium": [4.0, 2.0, 0.5, -4.0],
+            "relative_return_long": [6.0, 3.0, 0.5, -6.0],
+            "race_score": [88.0, 85.0, 50.0, 20.0],
+            "form": ["Charging", "Front-runner", "Steady", "Losing steam"],
+        }
+    )
+    table = render_relative_leaderboard(metrics, benchmark="SPY")
+
+    # Sorted by race_score descending: CHARGER, FRONTRUNNER, STEADY, LOSER.
+    assert "🚀 Charging" in _rich_text(table)
+    assert "🏆 Front-runner" in _rich_text(table)
+    assert "➖ Steady" in _rich_text(table)  # noqa: RUF001 -- deliberate per design spec
+    assert "📉 Losing steam" in _rich_text(table)
+    assert str(table.rows[0].style) == "green"
+    assert str(table.rows[1].style) == "cyan"
+    assert table.rows[2].style is None
+    assert str(table.rows[3].style) == "red"
+
+
+def test_render_relative_leaderboard_colors_pace_and_race_cells():
+    """Pace cells are green/red by sign and the Race cell is bucketed."""
+    metrics = pl.DataFrame(
+        {
+            "ticker": ["MIXED"],
+            "position": [1],
+            "places_gained": [0],
+            "relative_return_short": [2.0],
+            "relative_return_medium": [-1.5],
+            "relative_return_long": [0.0],
+            "race_score": [55.0],
+            "form": ["Steady"],
+        }
+    )
+    table = render_relative_leaderboard(metrics, benchmark="SPY")
+    ansi = _rich_ansi(table)
+    assert "\x1b[32m" in ansi  # green: positive pace short
+    assert "\x1b[31m" in ansi  # red: negative pace medium
+    assert "\x1b[33m" in ansi  # yellow: race score 55 in the 40-69 bucket
+
+
+def test_render_relative_leaderboard_unknown_form_unstyled_values():
+    """Missing form/score columns fall back to Unknown and unstyled cells."""
+    metrics = pl.DataFrame(
+        {
+            "ticker": ["NODATA"],
+            "position": [None],
+            "places_gained": [None],
+            "relative_return_short": [None],
+            "relative_return_medium": [None],
+            "relative_return_long": [None],
+            "race_score": [None],
+            "form": [None],
+        }
+    )
+    table = render_relative_leaderboard(metrics, benchmark="SPY")
+    text = _rich_text(table)
+    assert "❔ Unknown" in text
+    assert "n/a" in text
+    # No color codes (dim/bold codes like \x1b[2m may appear from the row
+    # style and header; only forbid color codes).
+    ansi = _rich_ansi(table)
+    assert "\x1b[32m" not in ansi
+    assert "\x1b[31m" not in ansi
+    assert "\x1b[33m" not in ansi


### PR DESCRIPTION
## Summary

Adds emoji + color styling to the etf-race leaderboard so the state of the field is scannable at a glance.

- **Form column**: emoji + whole-row tint per form — 🚀 Charging (green), 🏆 Front-runner (cyan), ⚡ Closing ground (yellow), ➖ Steady (no tint), 📉 Losing steam (red), 🍂 Fading (orange), 🐢 Back of field (dim red), ❔ Unknown (dim).
- **Pace columns**: green when positive (outperforming benchmark), red when negative.
- **Race column**: color buckets — green ≥ 70, yellow 40–69, red < 40.
- Docs: "Reading the table" section in `docs/etf-race.md`.

Styling is always on (no flag): Rich disables ANSI automatically off-TTY; emoji are plain text. All styling lives in `race.py`'s render layer; `pipeline.py` and the CLI are untouched. Sort order (race_score desc) unchanged.

## Testing

- 4 new unit tests for the style helpers (all form labels + fallback, pace sign boundaries, race score bucket boundaries incl. 70/40/39.9).
- 3 new table-level tests asserting rendered emoji, row styles, ANSI cell colors, and the null-safe path.
- Full suite: 342 passed, 98.04% coverage (gate: 95%).
- `make check` green: lint, format-check, radon/xenon A/B, test-cov.
- `ty check` clean (4 `# ty: ignore[invalid-argument-type]` on styled `Text` cells, repo precedent from transform.py).