### PR TITLE
feat(postgres): add database infrastructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 requires-python = ">=3.14,<3.15"
 dependencies = [
+    "adbc-driver-postgresql>=1.4.0",
     "duckdb>=1.5.0",
     "exchange-calendars>=4.13.2",
     "massive>=2.4.0",

--- a/src/tickerlake/config.py
+++ b/src/tickerlake/config.py
@@ -14,6 +14,8 @@ class Config:
         api_key: MASSIVE API key (loaded from MASSIVE_API_KEY env var when set;
             may be empty for read-only commands. Massive-backed commands enforce
             the requirement at their own boundary.)
+        db_uri: PostgreSQL URI (loaded from TICKERLAKE_DB_URI env var when set;
+            may be empty until a database command enforces the requirement.)
         output_dir: Directory for output files (defaults to current working directory)
         start_date: Start date for data collection (defaults to 10 years ago)
         end_date: End date for data collection (defaults to today)
@@ -22,6 +24,7 @@ class Config:
     """
 
     api_key: str = field(default="")
+    db_uri: str = field(default="")
     output_dir: Path = field(default_factory=Path.cwd)
     start_date: datetime.date = field(
         default_factory=lambda: (
@@ -41,4 +44,6 @@ class Config:
         """Validate and normalize configuration after initialization."""
         if not self.api_key:
             self.api_key = os.environ.get("MASSIVE_API_KEY", "")
+        if not self.db_uri:
+            self.db_uri = os.environ.get("TICKERLAKE_DB_URI", "")
         self.output_dir = Path(self.output_dir).resolve()

--- a/src/tickerlake/db.py
+++ b/src/tickerlake/db.py
@@ -1,0 +1,28 @@
+"""PostgreSQL connection helpers using ADBC."""
+
+from __future__ import annotations
+
+import os
+
+import adbc_driver_postgresql.dbapi as pg
+
+_DSN: str | None = None
+
+
+def get_dsn() -> str:
+    """Return the PostgreSQL DSN from TICKERLAKE_DB_URI."""
+    global _DSN  # noqa: PLW0603
+    if _DSN is None:
+        _DSN = os.environ.get("TICKERLAKE_DB_URI", "")
+    if not _DSN:
+        msg = "TICKERLAKE_DB_URI environment variable is required"
+        raise ValueError(msg)
+    return _DSN
+
+
+def connect() -> pg.Connection:
+    """Return a new ADBC PostgreSQL connection.
+
+    The caller is responsible for closing the connection.
+    """
+    return pg.connect(get_dsn())

--- a/src/tickerlake/pipeline.py
+++ b/src/tickerlake/pipeline.py
@@ -305,6 +305,13 @@ def _require_api_key(config: Config) -> None:
         raise ValueError(msg)
 
 
+def _require_db_uri(config: Config) -> None:
+    """Raise a clear error when a database command lacks credentials."""
+    if not config.db_uri:
+        msg = "TICKERLAKE_DB_URI environment variable is required"
+        raise ValueError(msg)
+
+
 def pivots(config: Config, ticker: str, timeframe: str = "weekly", k: int = 4) -> None:
     """Log confirmed pivots for a ticker/timeframe without writing any data."""
     ticker = ticker.upper()

--- a/src/tickerlake/schema.py
+++ b/src/tickerlake/schema.py
@@ -1,0 +1,136 @@
+"""PostgreSQL schema definitions for tickerlake data."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import adbc_driver_postgresql.dbapi as pg
+
+_DDL = (
+    "CREATE SCHEMA IF NOT EXISTS raw",
+    """
+    CREATE TABLE IF NOT EXISTS raw.raw_daily_bars (
+        date DATE NOT NULL,
+        ticker VARCHAR NOT NULL,
+        open REAL,
+        high REAL,
+        low REAL,
+        close REAL,
+        volume REAL,
+        vwap REAL,
+        transactions INTEGER,
+        PRIMARY KEY (ticker, date)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS raw.splits (
+        ticker VARCHAR NOT NULL,
+        execution_date DATE NOT NULL,
+        split_from REAL,
+        split_to REAL,
+        adjustment_factor DOUBLE PRECISION,
+        adjustment_type VARCHAR,
+        PRIMARY KEY (ticker, execution_date)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_raw_daily_bars_date ON raw.raw_daily_bars (date)",
+    "CREATE SCHEMA IF NOT EXISTS tickerlake",
+    """
+    CREATE TABLE IF NOT EXISTS tickerlake.daily_bars (
+        date DATE NOT NULL,
+        ticker VARCHAR NOT NULL,
+        open REAL,
+        high REAL,
+        low REAL,
+        close REAL,
+        volume REAL,
+        vwap REAL,
+        transactions INTEGER,
+        PRIMARY KEY (ticker, date)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS tickerlake.weekly_bars (
+        LIKE tickerlake.daily_bars INCLUDING ALL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS tickerlake.monthly_bars (
+        LIKE tickerlake.daily_bars INCLUDING ALL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS tickerlake.daily_metrics (
+        date DATE NOT NULL,
+        ticker VARCHAR NOT NULL,
+        sma_20 REAL,
+        sma_50 REAL,
+        sma_200 REAL,
+        atr_14 REAL,
+        atr_pct REAL,
+        adr_pct REAL,
+        volume_sma_20 REAL,
+        PRIMARY KEY (ticker, date)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS tickerlake.weekly_metrics (
+        LIKE tickerlake.daily_metrics INCLUDING ALL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS tickerlake.monthly_metrics (
+        LIKE tickerlake.daily_metrics INCLUDING ALL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS tickerlake.tickers (
+        ticker VARCHAR NOT NULL PRIMARY KEY,
+        name VARCHAR,
+        type VARCHAR,
+        primary_exchange VARCHAR,
+        cik VARCHAR,
+        active BOOLEAN
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS tickerlake.weekly_fib_zones (
+        ticker VARCHAR NOT NULL PRIMARY KEY,
+        as_of_date DATE,
+        swing_low REAL,
+        swing_high REAL,
+        range REAL,
+        swing_low_date DATE,
+        swing_high_date DATE,
+        bars_since_swing_high INTEGER,
+        ibz_low REAL,
+        ibz_high REAL,
+        smz_low REAL,
+        smz_high REAL,
+        current_price REAL,
+        pct_retracement REAL,
+        zone VARCHAR,
+        primary_degree INTEGER,
+        primary_status VARCHAR,
+        still_making_new_highs BOOLEAN,
+        zigzag_pct REAL,
+        bar_count INTEGER
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_daily_bars_date ON tickerlake.daily_bars (date)",
+    (
+        "CREATE INDEX IF NOT EXISTS idx_daily_metrics_date "
+        "ON tickerlake.daily_metrics (date)"
+    ),
+)
+
+
+def init_schema(conn: pg.Connection) -> None:
+    """Create tickerlake's PostgreSQL schemas, tables, and indexes if absent."""
+    cursor = conn.cursor()
+    try:
+        for statement in _DDL:
+            cursor.execute(statement)
+    finally:
+        cursor.close()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -25,6 +25,22 @@ class TestApiKey:
         assert config.output_dir == Path("./relative/path").resolve()
 
 
+class TestDbUri:
+    """Test PostgreSQL URI configuration."""
+
+    def test_db_uri_from_env(self) -> None:
+        """Config reads TICKERLAKE_DB_URI from the environment."""
+        with patch.dict(os.environ, {"TICKERLAKE_DB_URI": "postgresql://db"}):
+            config = Config()
+        assert config.db_uri == "postgresql://db"
+
+    def test_missing_db_uri_allowed(self) -> None:
+        """Config permits a missing URI until a command enforces it."""
+        with patch.dict(os.environ, {}, clear=True):
+            config = Config()
+        assert config.db_uri == ""
+
+
 class TestDates:
     """Test date configuration."""
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,37 @@
+"""Tests for PostgreSQL connection helpers."""
+
+from unittest.mock import patch
+
+import pytest
+
+from tickerlake import db
+
+
+class TestGetDsn:
+    """Tests for get_dsn()."""
+
+    def test_reads_uri_from_environment(self, monkeypatch) -> None:
+        """The URI is loaded once from the environment."""
+        monkeypatch.setenv("TICKERLAKE_DB_URI", "postgresql://db")
+        monkeypatch.setattr(db, "_DSN", None)
+
+        assert db.get_dsn() == "postgresql://db"
+        monkeypatch.setenv("TICKERLAKE_DB_URI", "postgresql://other")
+        assert db.get_dsn() == "postgresql://db"
+
+    def test_missing_uri_raises_clear_error(self, monkeypatch) -> None:
+        """A missing URI does not produce an unusable connection string."""
+        monkeypatch.delenv("TICKERLAKE_DB_URI", raising=False)
+        monkeypatch.setattr(db, "_DSN", None)
+
+        with pytest.raises(ValueError, match="TICKERLAKE_DB_URI"):
+            db.get_dsn()
+
+
+def test_connect_uses_configured_dsn(monkeypatch) -> None:
+    """connect() delegates the configured URI to the ADBC driver."""
+    monkeypatch.setattr(db, "_DSN", "postgresql://db")
+    with patch.object(db.pg, "connect") as connect:
+        db.connect()
+
+    connect.assert_called_once_with("postgresql://db")

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -152,6 +152,26 @@ def test_find_ticker_pivots_invalid_timeframe_does_not_read_db(
     read_bars.assert_not_called()
 
 
+def test_require_db_uri_accepts_configured_uri() -> None:
+    """_require_db_uri() accepts an explicitly configured PostgreSQL URI."""
+    from tickerlake.config import Config
+    from tickerlake.pipeline import _require_db_uri
+
+    _require_db_uri(Config(db_uri="postgresql://db"))
+
+
+def test_require_db_uri_rejects_missing_uri() -> None:
+    """_require_db_uri() reports a missing PostgreSQL URI clearly."""
+    from tickerlake.config import Config
+    from tickerlake.pipeline import _require_db_uri
+
+    with (
+        patch.dict(os.environ, {}, clear=True),
+        pytest.raises(ValueError, match="TICKERLAKE_DB_URI"),
+    ):
+        _require_db_uri(Config())
+
+
 @pytest.fixture
 def sample_bars():
     """Minimal bars DataFrame for pipeline tests."""

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,17 @@
+"""Tests for PostgreSQL schema initialization."""
+
+from unittest.mock import Mock
+
+from tickerlake.schema import _DDL, init_schema
+
+
+def test_init_schema_executes_all_ddl_and_closes_cursor() -> None:
+    """Schema initialization is applied through one cursor."""
+    cursor = Mock()
+    conn = Mock()
+    conn.cursor.return_value = cursor
+
+    init_schema(conn)
+
+    assert cursor.execute.call_count == len(_DDL)
+    cursor.close.assert_called_once_with()

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,44 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "adbc-driver-manager"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/f8/ed6475b49a7cf35ea888d5c95e7d4bc9dc6568f9d741f14c0573d622cc1e/adbc_driver_manager-1.12.0.tar.gz", hash = "sha256:45991f0c2de369d330c6a211ca2edbcce6389c5dc81cde70461bdeb6f8f7b268", size = 217579, upload-time = "2026-07-28T00:43:03.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/ea/f53b434fe36d0f138d147fc10a95784c8c0eeea1bec1f3f31eee5ec8bdb5/adbc_driver_manager-1.12.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a740d634118722f42af31176374fddbad3846fa2e6536f497bac145e9511cecc", size = 597579, upload-time = "2026-07-28T00:42:23.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/57/6208e66d9256550c2aff75db4a323a855a0d5d2d1bd639526f825d3e08b4/adbc_driver_manager-1.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8a77ae39832e67946009816d83c321e540a3024aad1419ccba24ddeb7b6a01f4", size = 610337, upload-time = "2026-07-28T00:42:25.051Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/cd/f5ea3f08191af5ae15041821fcb52bf35837dce1a9ac16fa039b3bfe308c/adbc_driver_manager-1.12.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:690f140ca67d49f995afac59f85441c3d5e896cd2fc8fd381423fe900e51f1f7", size = 4664297, upload-time = "2026-07-28T00:42:27.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/81/823a71a515078545eab8a4be8381206887129e11b91e9bf51ca2a9eea44d/adbc_driver_manager-1.12.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fd568c94874c0586d82f99de2bb5d2c02b4fa9c5bafe3d0d8ab353bddf9d2fd6", size = 4733739, upload-time = "2026-07-28T00:42:29.814Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/f7/7612d078d935344aee679a44a6283de6aae9008eb8e0ef80e475dd12dffa/adbc_driver_manager-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:57f5101fb2a853b1ffb81ff807b5e29a51ba14c64032eb0038b8dfd433b6d533", size = 777952, upload-time = "2026-07-28T00:42:40.881Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ad/2478338aaece38b8b72259dbfd4d4c84d9a038421e25bbc283e510d47555/adbc_driver_manager-1.12.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bb9db6e4a3bcd73153435a900b5ae40ad36f5875df93a8faf784d9fcf6833983", size = 615694, upload-time = "2026-07-28T00:42:31.932Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/a0/0592c85e653f005aa28de7733b3c3c4f0282238301694f76806e5f3cc1e1/adbc_driver_manager-1.12.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:07cae26bd5ccee6caa4227f817c0fd57f9ac131c2dd98e0c5d7fecfef61819c7", size = 628341, upload-time = "2026-07-28T00:42:33.481Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/65705a72f768bc2dda82623a74cf816609dfdff56f3ad22b073d4a1ea7f8/adbc_driver_manager-1.12.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:442ed2ee8ea62c475bf3478385555bb4f0b25d9d551087ffe40c73b91bf5431e", size = 4730268, upload-time = "2026-07-28T00:42:35.661Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b9/60ecde5d9dde5acc5576cb0ba5ffa34e154464e07fa295c57cd975ea27c7/adbc_driver_manager-1.12.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c2aa05c5dc52164692284b2df27fba5680dbc967b8e3ca704aabf5399667996", size = 4777527, upload-time = "2026-07-28T00:42:37.709Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/76/6749e0c0c437219780c65487cff67dc09a556c1fccf577a2b27f7b92a704/adbc_driver_manager-1.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:cfa08f8c7c63e3fa92eb4e26ef4d8a9520cf92a39281cd011821f6f16a963080", size = 793451, upload-time = "2026-07-28T00:42:39.222Z" },
+]
+
+[[package]]
+name = "adbc-driver-postgresql"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "adbc-driver-manager" },
+    { name = "importlib-resources" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/9e/cc757dfc1bb5472e35bf066ee4044f6b101bef61036512e8dfb4e97e7e08/adbc_driver_postgresql-1.12.0.tar.gz", hash = "sha256:766a002531bb99b691d2b92e7d928dea21c24ea567c03a6ee1edb61fe95b9187", size = 17793, upload-time = "2026-07-28T00:43:04.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/ba/152bbe1d4a1cc13e2da72e76a5045ee25338bc75294f1ebf04c90b787287/adbc_driver_postgresql-1.12.0-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:28548d9e16497d2cb4750bc8e9e1abad3d0f981c7c0ff7afe70323f4b71c70aa", size = 3068434, upload-time = "2026-07-28T00:42:43.495Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d3/f17e69423ed7217b70155d8e531c5cf6fb74f3b598a583e6cfe541dc3e7e/adbc_driver_postgresql-1.12.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:03c617aee8796f38a0a2f1af50ceae92d40f0974f3abbe7eefbaf009fecdc5ce", size = 3337707, upload-time = "2026-07-28T00:42:45.568Z" },
+    { url = "https://files.pythonhosted.org/packages/93/60/3b018e75661ac14a7aab7bb5cc1a95d72ddb9684abaee1e88a685406df81/adbc_driver_postgresql-1.12.0-py3-none-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b523f15051b27eef18c3a822296c2d94b894be552a0dbe49fe14059e2c706155", size = 3822540, upload-time = "2026-07-28T00:42:47.619Z" },
+    { url = "https://files.pythonhosted.org/packages/00/bb/ee19e7d56824c05892f82a3a2abca94fd2345b7de3dc22baac9e65a46acc/adbc_driver_postgresql-1.12.0-py3-none-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2c2dc9c29db07ba3e0caf293c57a7ab1259dd772d3725ff1f1aeedb7a1895dd4", size = 3512701, upload-time = "2026-07-28T00:42:49.519Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/02/7aa782cbb0134b09d1e67757c81332e0cd5e5697beecc8852468482193b0/adbc_driver_postgresql-1.12.0-py3-none-win_amd64.whl", hash = "sha256:5a3b5262eed6f28fb4c782b532e6a65caed1f2268fab7be736335ead49eed9dc", size = 3207946, upload-time = "2026-07-28T00:42:51.543Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
@@ -138,6 +176,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "importlib-resources"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/06/b56dfa750b44e86157093bc8fca0ab81dccbf5260510de4eaf1cb69b5b99/importlib_resources-7.1.0.tar.gz", hash = "sha256:0722d4c6212489c530f2a145a34c0a7a3b4721bc96a15fada5930e2a0b760708", size = 44985, upload-time = "2026-04-12T16:36:09.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/db/55a262f3606bebcae07cc14095338471ad7c0bbcaa37707e6f0ee49725b7/importlib_resources-7.1.0-py3-none-any.whl", hash = "sha256:1bd7b48b4088eddb2cd16382150bb515af0bd2c70128194392725f82ad2c96a1", size = 37232, upload-time = "2026-04-12T16:36:08.219Z" },
 ]
 
 [[package]]
@@ -487,6 +534,7 @@ name = "tickerlake"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "adbc-driver-postgresql" },
     { name = "duckdb" },
     { name = "exchange-calendars" },
     { name = "massive" },
@@ -507,6 +555,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "adbc-driver-postgresql", specifier = ">=1.4.0" },
     { name = "duckdb", specifier = ">=1.5.0" },
     { name = "exchange-calendars", specifier = ">=4.13.2" },
     { name = "massive", specifier = ">=2.4.0" },
@@ -557,6 +606,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/81/14/eaaa410a25bbdea19722109b5422380a0e211b3afcf3071d15953ddbd5db/ty-0.0.65-py3-none-win32.whl", hash = "sha256:cf529d538f1403b14b0511e6ec3cdb95d3d974adabf24cc76cedc533368c3edc", size = 11692341, upload-time = "2026-07-29T18:30:54.35Z" },
     { url = "https://files.pythonhosted.org/packages/bc/0f/6d48f206dce9d7e53fe3b5ea0f0ab5800dd9d2365b2b48f736783436c43f/ty-0.0.65-py3-none-win_amd64.whl", hash = "sha256:234a321e33c7cbbfbd67bfa0b01b685dd9c21f1841781a21e5ca1fa0b25f1d5d", size = 12729355, upload-time = "2026-07-29T18:30:57.275Z" },
     { url = "https://files.pythonhosted.org/packages/96/aa/7446f7725e303cf78e058c893af1f0552b9451895454908706f4c6c3494b/ty-0.0.65-py3-none-win_arm64.whl", hash = "sha256:b9424be1ec56d93ff18609fb1c0a0a2283fe1282cd6d1c7604f97d73b94d61f2", size = 12051375, upload-time = "2026-07-29T18:31:00.579Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add the ADBC PostgreSQL driver plus a cached PostgreSQL DSN and connection helper.
- Define idempotent raw and tickerlake schema DDL for the PostgreSQL migration.
- Add `TICKERLAKE_DB_URI` configuration and pipeline-boundary validation.
- Retain DuckDB and `output_dir` until their remaining callers are migrated so this infrastructure phase preserves current behavior.

## Test plan

- `make check` passes: 472 tests, 98.59% coverage, Ruff lint/format, and Xenon complexity checks.
- CodeRabbit local review timed out after 90 seconds without producing findings.
